### PR TITLE
Implemented: Set and get the shipping order preference(#2g4w5hz)

### DIFF
--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -31,10 +31,25 @@ const setUserTimeZone = async (payload: any): Promise <any>  => {
     data: payload
   });
 }
-
+const getShippingOrderPreference = async (payload: any): Promise<any> => {
+  return api({
+    url: "service/getUserPreference",
+    method: "post",
+    data: payload
+  });
+}
+const setShippingOrderPreference = async (payload: any): Promise<any> => {
+  return api({
+    url: "service/setUserPreference",
+    method: "post",
+    data: payload
+  });
+}
 export const UserService = {
     login,
     getAvailableTimeZones,
     getProfile,
     setUserTimeZone,
+    getShippingOrderPreference,
+    setShippingOrderPreference
 }

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -58,6 +58,9 @@ const actions: ActionTree<UserState, RootState> = {
       if (resp.data.userTimeZone !== localTimeZone) {
         emitter.emit('timeZoneDifferent', { profileTimeZone: resp.data.userTimeZone, localTimeZone});
       }
+      JSON.stringify(await UserService.getShippingOrderPreference({
+        'userPrefTypeId': 'BOPIS_SETTINGS'
+      }));
       commit(types.USER_INFO_UPDATED, resp.data);
       commit(types.USER_CURRENT_FACILITY_UPDATED, resp.data.facilities.length > 0 ? resp.data.facilities[0] : {});
     }
@@ -97,6 +100,10 @@ const actions: ActionTree<UserState, RootState> = {
 
   setShippingOrdersStatus( {state, commit }, payload){
     commit(types.USER_SHIPPING_ORDERS_STATUS_UPDATED, payload)
+    JSON.stringify(UserService.setShippingOrderPreference({
+      'userPrefTypeId': 'BOPIS_SETTINGS',
+      'userPrefValue': payload
+    }));
   }
 }
 export default actions;

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -58,9 +58,9 @@ const actions: ActionTree<UserState, RootState> = {
       if (resp.data.userTimeZone !== localTimeZone) {
         emitter.emit('timeZoneDifferent', { profileTimeZone: resp.data.userTimeZone, localTimeZone});
       }
-      JSON.stringify(await UserService.getShippingOrderPreference({
+      await UserService.getShippingOrderPreference({
         'userPrefTypeId': 'BOPIS_SETTINGS'
-      }));
+      });
       commit(types.USER_INFO_UPDATED, resp.data);
       commit(types.USER_CURRENT_FACILITY_UPDATED, resp.data.facilities.length > 0 ? resp.data.facilities[0] : {});
     }
@@ -100,10 +100,10 @@ const actions: ActionTree<UserState, RootState> = {
 
   setShippingOrdersStatus( {state, commit }, payload){
     commit(types.USER_SHIPPING_ORDERS_STATUS_UPDATED, payload)
-    JSON.stringify(UserService.setShippingOrderPreference({
+    UserService.setShippingOrderPreference({
       'userPrefTypeId': 'BOPIS_SETTINGS',
-      'userPrefValue': payload
-    }));
+      'userPrefValue': JSON.stringify({shippingOrderStatus: payload})
+    });
   }
 }
 export default actions;

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -51,7 +51,7 @@ const actions: ActionTree<UserState, RootState> = {
   /**
    * Get User profile
    */
-  async getProfile ( { commit }) {
+  async getProfile ( { commit, dispatch }) {
     const resp = await UserService.getProfile()
     if (resp.status === 200) {
       const localTimeZone = moment.tz.guess();
@@ -61,8 +61,13 @@ const actions: ActionTree<UserState, RootState> = {
       const shippingOrderPreference = await UserService.getShippingOrderPreference({
         'userPrefTypeId': 'BOPIS_SETTINGS'
       });
+
+      if (shippingOrderPreference.status == 200 && shippingOrderPreference.data && !hasError(shippingOrderPreference)) {
+        const value = JSON.parse(shippingOrderPreference.data.userPrefValue)
+        commit(types.USER_SHIPPING_ORDERS_STATUS_UPDATED, value.shippingOrderStatus)
+      }
+      
       commit(types.USER_INFO_UPDATED, resp.data);
-      commit(types.USER_SHIPPING_ORDERS_STATUS_UPDATED, shippingOrderPreference)
       commit(types.USER_CURRENT_FACILITY_UPDATED, resp.data.facilities.length > 0 ? resp.data.facilities[0] : {});
     }
     return resp;

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -62,7 +62,7 @@ const actions: ActionTree<UserState, RootState> = {
         'userPrefTypeId': 'BOPIS_SETTINGS'
       });
 
-      if (shippingOrderPreference.status == 200 && shippingOrderPreference.data && !hasError(shippingOrderPreference)) {
+      if (shippingOrderPreference.status == 200 && shippingOrderPreference.data?.userPrefValue && !hasError(shippingOrderPreference)) {
         const value = JSON.parse(shippingOrderPreference.data.userPrefValue)
         commit(types.USER_SHIPPING_ORDERS_STATUS_UPDATED, value.shippingOrderStatus)
       }

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -58,10 +58,11 @@ const actions: ActionTree<UserState, RootState> = {
       if (resp.data.userTimeZone !== localTimeZone) {
         emitter.emit('timeZoneDifferent', { profileTimeZone: resp.data.userTimeZone, localTimeZone});
       }
-      await UserService.getShippingOrderPreference({
+      const shippingOrderPreference = await UserService.getShippingOrderPreference({
         'userPrefTypeId': 'BOPIS_SETTINGS'
       });
       commit(types.USER_INFO_UPDATED, resp.data);
+      commit(types.USER_SHIPPING_ORDERS_STATUS_UPDATED, shippingOrderPreference)
       commit(types.USER_CURRENT_FACILITY_UPDATED, resp.data.facilities.length > 0 ? resp.data.facilities[0] : {});
     }
     return resp;
@@ -99,11 +100,11 @@ const actions: ActionTree<UserState, RootState> = {
   },
 
   setShippingOrdersStatus( {state, commit }, payload){
-    commit(types.USER_SHIPPING_ORDERS_STATUS_UPDATED, payload)
     UserService.setShippingOrderPreference({
       'userPrefTypeId': 'BOPIS_SETTINGS',
       'userPrefValue': JSON.stringify({shippingOrderStatus: payload})
     });
+    commit(types.USER_SHIPPING_ORDERS_STATUS_UPDATED, payload)
   }
 }
 export default actions;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #
https://github.com/hotwax/bopis/commit/380fc6655af64f21ee6d2e172672fecf59f9c9a6

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Now we can store shipping order preference and later use it as per need

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)