### PR TITLE
Fixed: the case when getting 404 for the getUserPreference api by handling the condition in try catch block(#2gnze24)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -58,13 +58,17 @@ const actions: ActionTree<UserState, RootState> = {
       if (resp.data.userTimeZone !== localTimeZone) {
         emitter.emit('timeZoneDifferent', { profileTimeZone: resp.data.userTimeZone, localTimeZone});
       }
-      const userPreferenceResp = await UserService.getUserPreference({
-        'userPrefTypeId': 'BOPIS_PREFERENCE'
-      });
+      try {
+        const userPreferenceResp = await UserService.getUserPreference({
+          'userPrefTypeId': 'BOPIS_PREFERENCE'
+        });
 
-      if (userPreferenceResp.status == 200 && !hasError(userPreferenceResp) && userPreferenceResp.data?.userPrefValue) {
-        const userPreference = JSON.parse(userPreferenceResp.data.userPrefValue)
-        commit(types.USER_PREFERENCE_UPDATED, userPreference)
+        if (userPreferenceResp.status == 200 && !hasError(userPreferenceResp) && userPreferenceResp.data?.userPrefValue) {
+          const userPreference = JSON.parse(userPreferenceResp.data.userPrefValue)
+          commit(types.USER_PREFERENCE_UPDATED, userPreference)
+        }
+      } catch (err) {
+        console.error(err)
       }
       commit(types.USER_INFO_UPDATED, resp.data);
       commit(types.USER_CURRENT_FACILITY_UPDATED, resp.data.facilities.length > 0 ? resp.data.facilities[0] : {});


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Unable to login when the getUserPreference API fails

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added a try catch block to handle the error case


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)