### PR TITLE
Fixed: issue of orders not found after changing the section by assigning empty string to the queryString before the method for fetching the orders is called(#2gnzkbw)

### DIFF
--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -287,9 +287,9 @@ export default defineComponent({
       });
     },
     segmentChanged (e: CustomEvent) {
+      this.queryString = ''
       this.segmentSelected = e.detail.value
       this.segmentSelected === 'open' ? this.getPickupOrders() : this.getPackedOrders();
-      this.queryString = ''
     },
     getShipGroups (items: any) {
       // To get unique shipGroup, further it will use on ion-card iteration


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
When searching for an order in the open segment and then changing the segment to packed results in an error

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Moved the code to empty the query string before calling the method to fetch the orders


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)