### PR TITLE
Improved: the query for fulfillmentStatus to not include orders whose fulfillment status is either Cancelled or Rejected(#2h194jz)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -19,7 +19,7 @@ const actions: ActionTree<OrderState , RootState> ={
       ...payload,
       shipmentMethodTypeId: !store.state.user.preference.showShippingOrders ? 'STOREPICKUP' : '',
       '-shipmentStatusId': '*',
-      '-fulfillmentStatus': 'Cancelled',
+      '-fulfillmentStatus': '(Cancelled OR Rejected)',
       orderStatusId: 'ORDER_APPROVED',
       orderTypeId: 'SALES_ORDER'
     })
@@ -107,7 +107,7 @@ const actions: ActionTree<OrderState , RootState> ={
       ...payload,
       shipmentMethodTypeId: !store.state.user.preference.showShippingOrders ? 'STOREPICKUP' : '',
       '-shipmentStatusId': '*',
-      '-fulfillmentStatus': 'Cancelled',
+      '-fulfillmentStatus': '(Cancelled OR Rejected)',
       orderStatusId: 'ORDER_APPROVED',
       orderTypeId: 'SALES_ORDER'
     })
@@ -179,7 +179,7 @@ const actions: ActionTree<OrderState , RootState> ={
       shipmentMethodTypeId: !store.state.user.preference.showShippingOrders ? 'STOREPICKUP' : '',
       shipmentStatusId: "SHIPMENT_PACKED",
       orderTypeId: 'SALES_ORDER',
-      '-fulfillmentStatus': 'Cancelled',
+      '-fulfillmentStatus': '(Cancelled OR Rejected)',
     })
 
     try {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Rejected Orders are visible on the open section, as the check for fulfillmentStatus Rejected is missing in the payload

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Updated the payload to not include those orders whose fulfillmentStatus is `Cancelled OR Rejected`


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)