### PR TITLE
Fixed: When rejecting order items duplicate entries are created and item is not rejected (#2h1em69)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -50,14 +50,16 @@ const actions: ActionTree<OrderState , RootState> ={
                   items: [{
                     orderItemSeqId: item.orderItemSeqId,
                     productId: item.productId,
-                    facilityId: item.facilityId
+                    facilityId: item.facilityId,
+                    quantity: item.itemQuantity
                   }]
                 })
               } else {
                 currentOrderPart.items.push({
                   orderItemSeqId: item.orderItemSeqId,
                   productId: item.productId,
-                  facilityId: item.facilityId
+                  facilityId: item.facilityId,
+                  quantity: item.itemQuantity
                 })
               }
 
@@ -138,14 +140,16 @@ const actions: ActionTree<OrderState , RootState> ={
                   items: [{
                     orderItemSeqId: item.orderItemSeqId,
                     productId: item.productId,
-                    facilityId: item.facilityId
+                    facilityId: item.facilityId,
+                    quantity: item.itemQuantity
                   }]
                 })
               } else {
                 currentOrderPart.items.push({
                   orderItemSeqId: item.orderItemSeqId,
                   productId: item.productId,
-                  facilityId: item.facilityId
+                  facilityId: item.facilityId,
+                  quantity: item.itemQuantity
                 })
               }
 


### PR DESCRIPTION

When rejecting order item from Bopis app using rejectOrderItem API, fulfillment status of item is not changed and there are duplicate entries created for the same with Cancelled and Cancelled + Rejected status.

Passed quantity as required for the rejectItem API for successful rejection

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes https://app.clickup.com/t/2h1em69

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)