### PR TITLE
Improved code by wrapping text on bopis order item details for products(#2h77kau)

### DIFF
--- a/src/components/ProductListItem.vue
+++ b/src/components/ProductListItem.vue
@@ -3,7 +3,7 @@
     <ion-thumbnail slot="start">
       <Image :src="getProduct(item.productId).mainImageUrl" />
     </ion-thumbnail>
-    <ion-label>
+    <ion-label class="ion-text-wrap">
       <h5>{{ getProduct(item.productId).brandName }}</h5>
       <h2>{{ getProduct(item.productId).productName }}</h2>
       <p class="ion-text-wrap">{{ getProduct(item.productId).internalName }}</p>

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -9,7 +9,7 @@
     <ion-content>
       <ion-list>
         <ion-item lines="none">
-          <ion-label>
+          <ion-label class="ion-text-wrap">
             <h2>{{ order.customer?.name }}</h2>
             <p>{{ order.orderName ? order.orderName : order.orderId }}</p>
           </ion-label>

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -24,7 +24,7 @@
         <div v-for="order in orders" :key="order.orderId" v-show="order.parts.length > 0">
           <ion-card v-for="(part, index) in order.parts" :key="index" @click.prevent="viewOrder(order, part)">
             <ion-item lines="none">
-              <ion-label>
+              <ion-label class="ion-text-wrap">
                 <h1>{{ order.customer.name }}</h1>
                 <p>{{ order.orderName ? order.orderName : order.orderId }}</p>
               </ion-label>
@@ -63,7 +63,7 @@
         <div v-for="order in packedOrders" :key="order.orderId" v-show="order.parts.length > 0">
           <ion-card v-for="(part, index) in order.parts" :key="index">
             <ion-item lines="none">
-              <ion-label>
+              <ion-label class="ion-text-wrap">
                 <h1>{{ order.customer.name }}</h1>
                 <p>{{ order.orderName ? order.orderName : order.orderId }}</p>
               </ion-label>


### PR DESCRIPTION
### Related Issues
#113 

Closes #113 

### Short Description and Why It's Useful
In this MR, we have wrapped the text of product details 


### Screenshots of Visual Changes before/after (If There Are Any)
![wrap-text](https://user-images.githubusercontent.com/82817616/176841409-7ce3bdf6-48a5-4af9-a832-a3614fe3edbf.png)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)