### PR TITLE
Improved markup and styling of segments in orders page(#2hcnrem)

### DIFF
--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -5,19 +5,17 @@
         <ion-title>{{ currentFacility.name }}</ion-title>
       </ion-toolbar>
 
-      <ion-toolbar>
-        <div>
-          <ion-searchbar @ionFocus="selectSearchBarText($event)" v-model="queryString" @keyup.enter="queryString = $event.target.value; searchOrders()" :placeholder= "$t('Search Orders')" />
-          <ion-segment v-model="segmentSelected" @ionChange="segmentChanged">
-            <ion-segment-button value="open">
-              <ion-label>{{ $t("Open") }}</ion-label>
-            </ion-segment-button>
-            <ion-segment-button value="packed">
-              <ion-label>{{ $t("Packed") }}</ion-label>
-            </ion-segment-button>
-          </ion-segment>
-        </div>
-      </ion-toolbar>
+      <div>
+        <ion-searchbar @ionFocus="selectSearchBarText($event)" v-model="queryString" @keyup.enter="queryString = $event.target.value; searchOrders()" :placeholder= "$t('Search Orders')" />
+        <ion-segment v-model="segmentSelected" @ionChange="segmentChanged">
+          <ion-segment-button value="open">
+            <ion-label>{{ $t("Open") }}</ion-label>
+          </ion-segment-button>
+          <ion-segment-button value="packed">
+            <ion-label>{{ $t("Packed") }}</ion-label>
+          </ion-segment-button>
+        </ion-segment>
+      </div>    
     </ion-header>
     <ion-content>
       <div v-if="segmentSelected === 'open'">
@@ -363,7 +361,7 @@ export default defineComponent({
 }
 
 @media (min-width: 991px){
-  ion-toolbar > div {
+  ion-header > div {
     display: flex;
   }
 }


### PR DESCRIPTION
### Related Issues
#114 

Closes #114 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
**Before:**
![localhost_8101_tabs_orders](https://user-images.githubusercontent.com/82817616/176848483-6e7b20d8-c99a-4bab-9e35-d6b327aa3f27.png)

**After:**
![localhost_8101_tabs_orders (1)](https://user-images.githubusercontent.com/82817616/176848559-acda83e2-2ced-49a9-b09a-0f60d2cfb315.png)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)