### PR TITLE
Fixed: Order is not removed after ready to pickup action  (#1zgmh46)

### DIFF
--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -273,18 +273,14 @@ export default defineComponent({
           },{
             text: header,
             handler: () => {
-              this.store.dispatch('order/quickShipEntireShipGroup', {order, part, facilityId: this.currentFacility.facilityId}).then((resp) => {
-                if (resp.data._EVENT_MESSAGE_) this.getPickupOrders();
-              })
+              this.store.dispatch('order/quickShipEntireShipGroup', {order, part, facilityId: this.currentFacility.facilityId})
             }
           }]
         });
       return alert.present();
     },
     async deliverShipment (order: any) {
-      await this.store.dispatch('order/deliverShipment', order).then((resp) => {
-        if (resp.data._EVENT_MESSAGE_) this.getPackedOrders();
-      });
+      await this.store.dispatch('order/deliverShipment', order)
     },
     segmentChanged (e: CustomEvent) {
       this.queryString = ''


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes https://app.clickup.com/t/1zgmh46

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When the order is marked ready to pickup/ship from open orders or ship/handover from packed orders, as the solr indexing takes some time and order is still in the list removed it locally and skipped any API calls


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)