### PR TITLE
Fixed: Search bar should reset on logout (#2hjmgzk)

### DIFF
--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -316,6 +316,7 @@ export default defineComponent({
     },
   },
   ionViewWillEnter () {
+    this.queryString = '';
     this.segmentSelected === 'open' ? this.getPickupOrders() : this.getPackedOrders();
   },
   setup () {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes https://app.clickup.com/t/2hjmgzk

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When the use logouts, the search bar should be reset. It will always give empty results if the instance is changed.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)