### PR TITLE
Fixed: Error when rejecting order with multiple items (#2hcqnu2)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -203,12 +203,17 @@ const actions: ActionTree<OrderState , RootState> ={
     }).catch(err => err);
   },
 
-  rejectOrderItems ({ commit }, data) {
+  async rejectOrderItems ({ commit }, data) {
     const payload = {
       'orderId': data.orderId
     }
+    const responses = [];
 
-    return Promise.all(data.items.map((item: any) => {
+    // https://blog.devgenius.io/using-async-await-in-a-foreach-loop-you-cant-c174b31999bd
+    // The forEach, map, reduce loops are not built to work with asynchronous callback functions.
+    // It doesn't wait for the promise of an iteration to be resolved before it goes on to the next iteration.
+    // We could use either the for…of the loop or the for(let i = 0;….)
+    for (const item of data.parts.items) {
       const params = {
         ...payload,
         'rejectReason': item.reason,
@@ -217,10 +222,10 @@ const actions: ActionTree<OrderState , RootState> ={
         'shipmentMethodTypeId': item.shipmentMethodTypeId,
         'quantity': parseInt(item.quantity)
       }
-      return OrderService.rejectOrderItem({'payload': params}).catch((err) => { 
-        return err;
-      })
-    }))
+      const resp = await OrderService.rejectOrderItem({'payload': params});
+      responses.push(resp);
+    }
+    return responses;
   },
 
   // clearning the orders state when logout, or user store is changed


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
In rejectOrderItem, as we are creating a new ship group for rejected items when making concurrent API calls multiple records with the same shipGroupSeqId are created causing primary key constraint failure. Subsequent API calls should be done in sequence and not in parallel

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)