### PR TITLE
Implemented: show order cards horizontally based on order ship group/part (#85zrv9fhc)

### DIFF
--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -62,7 +62,7 @@
       </div>      
       <div v-if="segmentSelected === 'packed'">
         <div v-for="order in packedOrdersByParts" :key="order.orderId" v-show="order.parts.length > 0">
-          <ion-card v-for="(part, index) in order.parts" :key="index">
+          <ion-card>
             <ion-item lines="none">
               <ion-label class="ion-text-wrap">
                 <h1>{{ order.customer.name }}</h1>
@@ -71,7 +71,7 @@
               <ion-badge v-if="order.placedDate" color="dark" slot="end">{{ timeFromNow(order.placedDate) }}</ion-badge>
             </ion-item>
 
-            <ProductListItem v-for="item in part.items" :key="item.productId" :item="item" />
+            <ProductListItem v-for="item in order.part.items" :key="item.productId" :item="item" />
 
             <ion-item v-if="order.customer.phoneNumber">
               <ion-icon :icon="callOutline" slot="start" />
@@ -89,9 +89,9 @@
             </ion-item>
             <div class="border-top">
               <ion-button :disabled="!hasPermission(Actions.APP_ORDER_UPDATE)" fill="clear" @click.stop="deliverShipment(order)">
-                {{ part.shipmentMethodEnum.shipmentMethodEnumId === 'STOREPICKUP' ? $t("Handover") : $t("Ship") }}
+                {{ order.part.shipmentMethodEnum.shipmentMethodEnumId === 'STOREPICKUP' ? $t("Handover") : $t("Ship") }}
               </ion-button>
-              <ion-button v-if="part.shipmentMethodEnum.shipmentMethodEnumId === 'STOREPICKUP'" fill="clear" slot="end" @click="sendReadyForPickupEmail(order)">
+              <ion-button v-if="order.part.shipmentMethodEnum.shipmentMethodEnumId === 'STOREPICKUP'" fill="clear" slot="end" @click="sendReadyForPickupEmail(order)">
                 <ion-icon slot="icon-only" :icon="mail" />
               </ion-button>
               <ion-button v-if="showPackingSlip" fill="clear" slot="end" @click="printPackingSlip(order)">
@@ -430,9 +430,7 @@ export default defineComponent({
       return alert.present();
     },
     getPackedOrdersByParts(packedOrders: Array<any>) {
-      this.packedOrdersByParts = packedOrders.flatMap((order: any) => 
-        order.parts.length > 1 ? order.parts.map((item: any) => ({ ...order, parts: [item] })) : order
-      )
+      this.packedOrdersByParts = packedOrders.flatMap((order: any) => order.parts.map((part: any) => ({ ...order, part })))
     }
   },
   ionViewWillEnter () {

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -422,9 +422,7 @@ export default defineComponent({
       return alert.present();
     },
     getOrdersByPart(orders: Array<any>) {
-      if(Object.keys(orders).length) {
-        return orders.flatMap((order: any) => order.parts.map((part: any) => ({ ...order, part })))
-      }
+      return Object.keys(orders).length ? orders.flatMap((order: any) => order.parts.map((part: any) => ({ ...order, part }))) : [];
     }
   },
   ionViewWillEnter () {

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -22,7 +22,7 @@
     </ion-header>
     <ion-content>
       <div v-if="segmentSelected === 'open'">
-        <div v-for="order in openOrdersByPart" :key="order.orderId" v-show="order.parts.length > 0">
+        <div v-for="(order, index) in getOrdersByPart(orders)" :key="index" v-show="order.parts.length > 0">
           <ion-card button @click.prevent="viewOrder(order, order.part)">
             <ion-item lines="none">
               <ion-label class="ion-text-wrap">
@@ -61,7 +61,7 @@
         </div>
       </div>      
       <div v-if="segmentSelected === 'packed'">
-        <div v-for="order in packedOrdersByPart" :key="order.orderId" v-show="order.parts.length > 0">
+        <div v-for="(order, index) in getOrdersByPart(packedOrders)" :key="index" v-show="order.parts.length > 0">
           <ion-card>
             <ion-item lines="none">
               <ion-label class="ion-text-wrap">
@@ -102,7 +102,7 @@
         </div>
       </div>
       <div v-if="segmentSelected === 'completed'">
-        <div v-for="order in completedOrdersByPart" :key="order.orderId" v-show="order.parts.length > 0">
+        <div v-for="(order, index) in getOrdersByPart(completedOrders)" :key="index" v-show="order.parts.length > 0">
           <ion-card>
             <ion-item lines="none">
               <ion-label class="ion-text-wrap">
@@ -222,10 +222,7 @@ export default defineComponent({
   },
   data() {
     return {
-      queryString: '',
-      openOrdersByPart: [] as Array<any>,
-      packedOrdersByPart: [] as Array<any>,
-      completedOrdersByPart: [] as Array<any>
+      queryString: ''
     }
   },
   methods: {
@@ -291,21 +288,18 @@ export default defineComponent({
       const viewIndex = vIndex ? vIndex : 0;
 
       await this.store.dispatch("order/getOpenOrders", { viewSize, viewIndex, queryString: this.queryString, facilityId: this.currentFacility.facilityId });
-      this.getOrdersByPart(this.orders, 'open');
     },
     async getPackedOrders (vSize?: any, vIndex?: any) {
       const viewSize = vSize ? vSize : process.env.VUE_APP_VIEW_SIZE;
       const viewIndex = vIndex ? vIndex : 0;
 
       await this.store.dispatch("order/getPackedOrders", { viewSize, viewIndex, queryString: this.queryString, facilityId: this.currentFacility.facilityId });
-      this.getOrdersByPart(this.packedOrders, 'packed');
     },
     async getCompletedOrders (vSize?: any, vIndex?: any) {
       const viewSize = vSize ? vSize : process.env.VUE_APP_VIEW_SIZE;
       const viewIndex = vIndex ? vIndex : 0;
 
       await this.store.dispatch("order/getCompletedOrders", { viewSize, viewIndex, queryString: this.queryString, facilityId: this.currentFacility.facilityId });
-      this.getOrdersByPart(this.completedOrders, 'completed');
     },
     async loadMoreProducts (event: any) {
       if (this.segmentSelected === 'open') {
@@ -427,14 +421,9 @@ export default defineComponent({
         });
       return alert.present();
     },
-    getOrdersByPart(orders: Array<any>, type: string) {
-      const orderByParts = orders.flatMap((order: any) => order.parts.map((part: any) => ({ ...order, part })))
-      if (type === 'open') {
-        this.openOrdersByPart = orderByParts
-      } else if (type === 'packed') {
-        this.packedOrdersByPart = orderByParts
-      } else {
-        this.completedOrdersByPart = orderByParts
+    getOrdersByPart(orders: Array<any>) {
+      if(Object.keys(orders).length) {
+        return orders.flatMap((order: any) => order.parts.map((part: any) => ({ ...order, part })))
       }
     }
   },

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -61,7 +61,7 @@
         </div>
       </div>      
       <div v-if="segmentSelected === 'packed'">
-        <div v-for="order in packedOrders" :key="order.orderId" v-show="order.parts.length > 0">
+        <div v-for="order in packedOrdersByParts" :key="order.orderId" v-show="order.parts.length > 0">
           <ion-card v-for="(part, index) in order.parts" :key="index">
             <ion-item lines="none">
               <ion-label class="ion-text-wrap">
@@ -222,7 +222,8 @@ export default defineComponent({
   },
   data() {
     return {
-      queryString: ''
+      queryString: '',
+      packedOrdersByParts: [] as Array<any>
     }
   },
   methods: {
@@ -294,6 +295,7 @@ export default defineComponent({
       const viewIndex = vIndex ? vIndex : 0;
 
       await this.store.dispatch("order/getPackedOrders", { viewSize, viewIndex, queryString: this.queryString, facilityId: this.currentFacility.facilityId });
+      this.getPackedOrdersByParts(this.packedOrders);
     },
     async getCompletedOrders (vSize?: any, vIndex?: any) {
       const viewSize = vSize ? vSize : process.env.VUE_APP_VIEW_SIZE;
@@ -426,6 +428,11 @@ export default defineComponent({
           }]
         });
       return alert.present();
+    },
+    getPackedOrdersByParts(packedOrders: Array<any>) {
+      this.packedOrdersByParts = packedOrders.flatMap((order: any) => 
+        order.parts.length > 1 ? order.parts.map((item: any) => ({ ...order, parts: [item] })) : order
+      )
     }
   },
   ionViewWillEnter () {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #222 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Implemented rendering of packed orders based on ship group (order parts) in the UI. 
This fixed the issue of duplicate cards showing up vertically in the UI for orders having different ship groups.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
#### Before -
![before](https://user-images.githubusercontent.com/59442907/229721724-fa7e60ce-1310-446f-9ee0-8fb152079647.png)

#### After - 
![after](https://user-images.githubusercontent.com/59442907/229721720-19d2da3e-d3ea-4774-a5ec-5da4f4b1b002.png)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
