### PR TITLE
Improved: Orders rejected in BOPIS app should go to Store Pickup Rejected Queue (#251)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -472,24 +472,25 @@ const actions: ActionTree<OrderState , RootState> ={
     }).catch(err => err);
   },
 
-  async rejectOrderItems ({ commit }, data) {
+  async rejectOrderItems ({ commit }, order) {
     const payload = {
-      'orderId': data.orderId
+      'orderId': order.orderId
     }
-    const responses = [];
+    const responses = [] as any;
 
     // https://blog.devgenius.io/using-async-await-in-a-foreach-loop-you-cant-c174b31999bd
     // The forEach, map, reduce loops are not built to work with asynchronous callback functions.
     // It doesn't wait for the promise of an iteration to be resolved before it goes on to the next iteration.
     // We could use either the for…of the loop or the for(let i = 0;….)
-    for (const item of data.parts.items) {
+    for (const item of order.part.items) {
       const params = {
         ...payload,
         'rejectReason': item.reason,
         'facilityId': item.facilityId,
         'orderItemSeqId': item.orderItemSeqId,
-        'shipmentMethodTypeId': data.parts.shipmentMethodEnum.shipmentMethodEnumId,
-        'quantity': parseInt(item.quantity)
+        'shipmentMethodTypeId': order.part.shipmentMethodEnum.shipmentMethodEnumId,
+        'quantity': parseInt(item.quantity),
+        ...(order.part.shipmentMethodEnum.shipmentMethodEnumId === "STOREPICKUP" && ({"naFacilityId": "PICKUP_REJECTED"})),
       }
       const resp = await OrderService.rejectOrderItem({'payload': params});
       responses.push(resp);

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -149,7 +149,7 @@ export default defineComponent({
           },{
             text: this.$t('Reject Order'),
             handler: () => {
-              this.store.dispatch('order/setUnfillableOrderOrItem', { orderId: order.orderId, parts: this.getCurrentOrderPart() }).then((resp) => {
+              this.store.dispatch('order/setUnfillableOrderOrItem', { orderId: order.orderId, part: this.getCurrentOrderPart() }).then((resp) => {
                 if (resp) this.router.push('/tabs/orders')
               })
             },


### PR DESCRIPTION


Currently, if an order item is rejected from BOPIS app the item goes to brokering queue, but store pickup order should not be brokered to any location for fulfillment. Orders rejected in BOPIS app or store pickup orders should go to Store Pickup Rejected Queue.

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #251 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
