### PR TITLE
 Implemented:  picker tracking feature in order handover process

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -72,7 +72,8 @@ const actions: ActionTree<OrderState , RootState> ={
 
               return arr
             }, []),
-            placedDate: orderItem.orderDate
+            placedDate: orderItem.orderDate,
+            pickers: orderItem.pickers
           }
         })
 
@@ -162,7 +163,8 @@ const actions: ActionTree<OrderState , RootState> ={
 
               return arr
             }, []),
-            placedDate: orderItem.orderDate
+            placedDate: orderItem.orderDate,
+            pickers: orderItem.pickers
           }
         })
 
@@ -233,7 +235,8 @@ const actions: ActionTree<OrderState , RootState> ={
 
               return arr
             }, []),
-            placedDate: orderItem.orderDate
+            placedDate: orderItem.orderDate,
+            pickers: orderItem.pickers
           }
         })
         this.dispatch('product/getProductInformation', { orders });
@@ -302,7 +305,8 @@ const actions: ActionTree<OrderState , RootState> ={
 
               return arr
             }, []),
-            placedDate: orderItem.orderDate
+            placedDate: orderItem.orderDate,
+            pickers: orderItem.pickers
           }
         })
         this.dispatch('product/getProductInformation', { orders });

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -72,8 +72,7 @@ const actions: ActionTree<OrderState , RootState> ={
 
               return arr
             }, []),
-            placedDate: orderItem.orderDate,
-            pickers: orderItem.pickers
+            placedDate: orderItem.orderDate
           }
         })
 
@@ -163,8 +162,7 @@ const actions: ActionTree<OrderState , RootState> ={
 
               return arr
             }, []),
-            placedDate: orderItem.orderDate,
-            pickers: orderItem.pickers
+            placedDate: orderItem.orderDate
           }
         })
 

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -33,7 +33,6 @@
               <ion-label class="ion-text-wrap">
                 <h1>{{ order.customer.name }}</h1>
                 <p>{{ order.orderName ? order.orderName : order.orderId }}</p>
-                <p>Picked by {{ order.pickers[0].split('/')[1] }}</p>
               </ion-label>
               <div class="metadata">
                 <ion-badge v-if="order.placedDate" color="dark">{{ timeFromNow(order.placedDate) }}</ion-badge>
@@ -73,6 +72,8 @@
               <ion-label class="ion-text-wrap">
                 <h1>{{ order.customer.name }}</h1>
                 <p>{{ order.orderName ? order.orderName : order.orderId }}</p>
+                <p v-if="order.pickers && configurePicker">{{ getPickersForOrder(order.pickers) }}</p>
+                <p v-if="!order.pickers && configurePicker">No picker assigned.</p>
               </ion-label>
               <ion-badge v-if="order.placedDate" color="dark" slot="end">{{ timeFromNow(order.placedDate) }}</ion-badge>
             </ion-item>
@@ -114,6 +115,8 @@
               <ion-label class="ion-text-wrap">
                 <h1>{{ order.customer.name }}</h1>
                 <p>{{ order.orderName ? order.orderName : order.orderId }}</p>
+                <p v-if="order.pickers && configurePicker">{{ getPickersForOrder(order.pickers) }}</p>
+                <p v-if="!order.pickers && configurePicker">No picker assigned.</p>
               </ion-label>
               <ion-badge v-if="order.placedDate" color="dark" slot="end">{{ timeFromNow(order.placedDate) }}</ion-badge>
             </ion-item>
@@ -419,6 +422,16 @@ export default defineComponent({
     },
     viewShipToStoreOrders() {
       this.$router.push({ path: '/ship-to-store-orders' })
+    },
+    getPickersForOrder(pickers: [string]){
+      let pickersInfo = 'Picked by ';
+      pickers.forEach((picker: any, index: number) => {
+        pickersInfo += picker.split('/')[1];
+        if(pickers.length != index + 1){
+          pickersInfo += ', ';
+        }
+      });
+      return pickersInfo;
     }
   },
   ionViewWillEnter () {

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -33,6 +33,7 @@
               <ion-label class="ion-text-wrap">
                 <h1>{{ order.customer.name }}</h1>
                 <p>{{ order.orderName ? order.orderName : order.orderId }}</p>
+                <p>Picked by {{ order.pickers[0].split('/')[1] }}</p>
               </ion-label>
               <div class="metadata">
                 <ion-badge v-if="order.placedDate" color="dark">{{ timeFromNow(order.placedDate) }}</ion-badge>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #216

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
added a picker tracking feature to the handover process. This feature would allow users to view the picker for packed and completed orders, making it easier to identify and contact the picker.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
**If picker assigned:-**
![picker1](https://github.com/hotwax/bopis/assets/67117461/cf6ad776-6350-4b80-b253-2a89bf9bbd20)
**If picker not assigned : -**
![picker2](https://github.com/hotwax/bopis/assets/67117461/6d424e8d-072b-49b9-8a9a-bb0e9bbf2de1)




### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
