### PR TITLE
Implemented: centralized oms instance navigator in settings page from dxp-components (#177)

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -244,7 +244,6 @@ export default defineComponent({
       userProfile: 'user/getUserProfile',
       currentFacility: 'user/getCurrentFacility',
       currentEComStore: 'user/getCurrentEComStore',
-      instanceUrl: 'user/getInstanceUrl',
       configurePicker: "user/configurePicker",
       showShippingOrders: 'user/showShippingOrders',
       showPackingSlip: 'user/showPackingSlip',

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -34,23 +34,7 @@
         <h1>{{ $t('OMS') }}</h1>
       </div>
       <section>
-        <ion-card>
-          <ion-card-header>
-            <ion-card-subtitle>
-              {{ $t("OMS instance") }}
-            </ion-card-subtitle>
-            <ion-card-title>
-              {{ instanceUrl }}
-            </ion-card-title>
-          </ion-card-header>
-          <ion-card-content>
-            {{ $t('This is the name of the OMS you are connected to right now. Make sure that you are connected to the right instance before proceeding.') }}
-          </ion-card-content>
-          <ion-button @click="goToOms" fill="clear">
-            {{ $t('Go to OMS') }}
-            <ion-icon slot="end" :icon="openOutline" />
-          </ion-button>
-        </ion-card>
+        <OmsInstanceNavigator />
 
         <ion-card>
           <ion-card-header>
@@ -321,9 +305,6 @@ export default defineComponent({
     },
     setConfigurePickerPreference (ev: any){
       this.store.dispatch('user/setUserPreference', { configurePicker: ev.detail.checked })
-    },
-    goToOms(){
-      window.open(this.instanceUrl.startsWith('http') ? this.instanceUrl.replace('api/', "") : `https://${this.instanceUrl}.hotwax.io/`, '_blank', 'noopener, noreferrer');
     },
     getDateTime(time: any) {
       return DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED);

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,4 @@
+const path = require('path')
 require("@hotwax/app-version-info")
 module.exports = {
   pluginOptions: {
@@ -10,6 +11,13 @@ module.exports = {
       compositionOnly: false,
       fullInstall: true,
       enableInSFC: true
+    }
+  },
+  configureWebpack: {
+    resolve: {
+      alias: {
+        vue: path.resolve('./node_modules/vue')
+      }
     }
   },
   runtimeCompiler: true,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue: https://github.com/hotwax/dxp-components/issues/177

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Used the centralized oms instance navigator on the settings page which is implemented in dxp-components.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
