### PR TITLE
Improved: removing all items from order details on reject all event

### DIFF
--- a/src/components/RejectOrderModal.vue
+++ b/src/components/RejectOrderModal.vue
@@ -105,7 +105,9 @@ export default defineComponent({
               this.store.dispatch('order/setUnfillableOrderOrItem', { orderId: this.order.orderId, part }).then((resp) => {
                 if (resp) {
                   // Mark current order as rejected
-                  this.store.dispatch('order/updateCurrent', { order: { ...this.order, rejected: true } })
+                  const order = { ...this.order, part: { ...this.order.part, items: [] } };
+
+                  this.store.dispatch('order/updateCurrent', { order: { ...order, rejected: true } })
                 }
                 this.closeModal();
               })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,7 @@
 { 
   "App": "App",
   "All items were rejected from the order": "All items were rejected from the order",
+  "All order items are rejected": "All order items are rejected",
   "Allow partial rejection": "Allow partial rejection",
   "An email notification will be sent to that their order is ready for pickup. This order will also be moved to the packed orders tab.": "An email notification will be sent to { customerName } that their order is ready for pickup.{ space } This order will also be moved to the packed orders tab.",
   "An email notification will be sent to that their order is ready for pickup.": "An email notification will be sent to { customerName } that their order is ready for pickup.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,6 +1,7 @@
 {
   "App": "Aplicación",
   "All items were rejected from the order": "All items were rejected from the order",
+  "All order items are rejected": "All order items are rejected",
   "Allow partial rejection": "Allow partial rejection",
   "An email notification will be sent to that their order is ready for pickup. This order will also be moved to the packed orders tab.": "Se enviará una notificación por correo electrónico a {customerName} de que su pedido está listo para recoger.{ space } Este pedido también se moverá a la pestaña de pedidos empacados.",
   "An email notification will be sent to that their order is ready for pickup.": "Se enviará una notificación por correo electrónico a {customerName} de que su pedido está listo para recoger.",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1,6 +1,7 @@
 {
   "App": "App",
   "All items were rejected from the order": "All items were rejected from the order",
+  "All order items are rejected": "All order items are rejected",
   "Allow partial rejection": "Allow partial rejection",
   "An email notification will be sent to that their order is ready for pickup. This order will also be moved to the packed orders tab.": "{ customerName }様宛に注文の受け取り準備が完了したことをお知らするメールが送信されます。{ space } この注文は「梱包済み注文」タブに移動されます.",
   "An email notification will be sent to that their order is ready for pickup.": "{ customerName }様宛に注文の受け取り準備が完了したことをお知らするメールが送信されます。",

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -100,7 +100,7 @@
               </ion-button>
             </div>
           </ion-card>
-          <p v-if="!order.part?.items?.length" class="empty-state">{{ translate('No items found') }}</p>
+          <p v-if="!order.part?.items?.length" class="empty-state">{{ translate('All order items are rejected') }}</p>
         </section>
       </main>
 


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved the code to remove all items from the state and order details page when clicking reject all items buttons and displaying am empty state text.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
