### PR TITLE
Fixed: issue of product identifier api fails as token is not set before fetching product identifier(#250)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -85,9 +85,6 @@ const actions: ActionTree<UserState, RootState> = {
       const currentEComStore = await UserService.getCurrentEComStore(token, currentFacility?.facilityId);
       const userPreference = await getUserPreference(token, getters['getBaseUrl'], 'BOPIS_PREFERENCE')
 
-      // Get product identification from api using dxp-component
-      await useProductIdentificationStore().getIdentificationPref(currentEComStore?.productStoreId)
-
       /*  ---- Guard clauses ends here --- */
 
       setPermissions(appPermissions);
@@ -103,6 +100,9 @@ const actions: ActionTree<UserState, RootState> = {
       commit(types.USER_PREFERENCE_UPDATED, userPreference)
       commit(types.USER_PERMISSIONS_UPDATED, appPermissions);
       commit(types.USER_TOKEN_CHANGED, { newToken: token })
+
+      // Get product identification from api using dxp-component
+      await useProductIdentificationStore().getIdentificationPref(currentEComStore?.productStoreId)
 
       //fetching partial order rejection config for BOPIS orders
       await dispatch("getPartialOrderRejectionConfig");


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fetching product identifier on login fails as the token is not set, so moved the logic to fetch product identifier setting after token is updated in oms-api.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
