### PR TITLE
Fixed: product identifier not visible on refresh

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -89,6 +89,14 @@ export default defineComponent({
       });
     emitter.on('presentLoader', this.presentLoader);
     emitter.on('dismissLoader', this.dismissLoader);
+
+    // If fetching identifier without checking token then on login the app stucks in a loop, as the mounted hook runs before
+    // token is available which results in api failure as unauthenticated, thus making logout call and then login call again and so on.
+    if(this.userToken) {
+      // Get product identification from api using dxp-component
+      await useProductIdentificationStore().getIdentificationPref(this.currentEComStore?.productStoreId)
+        .catch((error) => console.error(error));
+    }
   },
   unmounted() {
     emitter.off('presentLoader', this.presentLoader);


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added call to fetch product identifier inside app mounted hook and added check to make this call only when the token is available, as when login the mounted hook runs but we does not have token which results in api failure as unauthenticated and app logout and thus stucks in a loop

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
