### PR TITLE
Implemented: Spinner in timezone modal so users can see that data is being fetched

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -40,6 +40,7 @@
   "Failed to load packing slip": "Failed to load packing slip",
   "Failed to update configuration": "Failed to update configuration",
   "Failed to print shipping label and packing slip": "Failed to print shipping label and packing slip",
+  "Fetching time zones": "Fetching time zones",
   "First name": "First name",
   "Generate packing slips": "Generate packing slips",
   "Generate shipping documents": "Generate shipping documents",

--- a/src/views/TimezoneModal.vue
+++ b/src/views/TimezoneModal.vue
@@ -59,6 +59,7 @@ import {
   IonRadioGroup,
   IonRadio,
   IonSearchbar,
+  IonSpinner,
   IonTitle,
   IonToolbar,
   modalController,
@@ -87,6 +88,7 @@ export default defineComponent({
     IonRadioGroup,
     IonRadio,
     IonSearchbar,
+    IonSpinner,
     IonTitle,
     IonToolbar 
   },

--- a/src/views/TimezoneModal.vue
+++ b/src/views/TimezoneModal.vue
@@ -15,10 +15,15 @@
 
   <ion-content class="ion-padding">
     <!-- Empty state -->
-    <div class="empty-state" v-if="filteredTimeZones.length === 0">
-      <p>{{ translate("No time zone found")}}</p>
+    <div class="empty-state" v-if="isLoading">
+      <ion-item lines="none">
+        <ion-spinner color="secondary" name="crescent" slot="start" />
+        {{ $t("Fetching time zones") }}
+      </ion-item>
     </div>
-
+    <div class="empty-state" v-else-if="filteredTimeZones.length === 0">
+      <p>{{ $t("No time zone found") }}</p>
+    </div>
     <!-- Timezones -->
     <div v-else>
       <ion-list>
@@ -90,7 +95,8 @@ export default defineComponent({
       queryString: '',
       filteredTimeZones: [],
       timeZones: [],
-      timeZoneId: ''
+      timeZoneId: '',
+      isLoading: false
     }
   },
   methods: {
@@ -127,6 +133,7 @@ export default defineComponent({
       });
     },
     async getAvailableTimeZones() {
+      this.isLoading = true;
       const resp = await UserService.getAvailableTimeZones()
       if(resp.status === 200 && !hasError(resp)) {
         // We are filtering valid the timeZones coming with response here
@@ -135,6 +142,7 @@ export default defineComponent({
         });
         this.findTimeZone();
       }
+      this.isLoading = false;
     },
     async selectSearchBarText(event: any) {
       const element = await event.target.getInputElement()


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
I have incorporated a spinner in the TimeZoneModal to provide users with a visual cue, allowing them to easily discern when data is being fetched. This not only enhances the user experience but also ensures that users can perceive the ongoing data retrieval process
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/hotwax/bopis/assets/83332530/c34a110b-dab5-4a5b-987f-686d2083be1f)



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
