### PR TITLE
Fixed: infinite scroll issue when used with searchbar(dxp-289) 

### DIFF
--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -25,6 +25,13 @@
         </ion-radio-group>
       </div>
     </ion-list>
+     <!--
+        When searching for a keyword, and if the user moves to the last item, then the didFire value inside infinite scroll becomes true and thus the infinite scroll does not trigger again on the same page(https://github.com/hotwax/users/issues/84).
+        In ionic v7.6.0, an issue related to infinite scroll has been fixed that when more items can be added to the DOM, but infinite scroll does not fire as the window is not completely filled with the content(https://github.com/ionic-team/ionic-framework/issues/18071).
+        The above fix in ionic 7.6.0 is resulting in the issue of infinite scroll not being called again.
+        To fix this, we have added a key with value as queryString(searched keyword), so that the infinite scroll component can be re-rendered
+        whenever the searched string is changed resulting in the correct behaviour for infinite scroll
+      -->
     <ion-infinite-scroll
       @ionInfinite="loadMorePickers($event)"
       threshold="100px"

--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -10,7 +10,7 @@
     </ion-toolbar>
   </ion-header>
 
-  <ion-content>
+  <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()">
     <ion-searchbar v-model="queryString" @keyup.enter="queryString = $event.target.value; searchPicker()"/>
 
     <div class="ion-text-center ion-margin-top" v-if="!availablePickers.length">{{ translate('No picker found') }}</div>
@@ -27,16 +27,18 @@
     </ion-list>
      <!--
         When searching for a keyword, and if the user moves to the last item, then the didFire value inside infinite scroll becomes true and thus the infinite scroll does not trigger again on the same page(https://github.com/hotwax/users/issues/84).
+        Also if we are at the section that has been loaded by infinite-scroll and then move to the details page then the list infinite scroll does not work after coming back to the page
         In ionic v7.6.0, an issue related to infinite scroll has been fixed that when more items can be added to the DOM, but infinite scroll does not fire as the window is not completely filled with the content(https://github.com/ionic-team/ionic-framework/issues/18071).
         The above fix in ionic 7.6.0 is resulting in the issue of infinite scroll not being called again.
-        To fix this, we have added a key with value as queryString(searched keyword), so that the infinite scroll component can be re-rendered
-        whenever the searched string is changed resulting in the correct behaviour for infinite scroll
+        To fix this we have maintained another variable `isScrollingEnabled` to check whether the scrolling can be performed or not.
+        If we do not define an extra variable and just use v-show to check for `isScrollable` then when coming back to the page infinite-scroll is called programatically.
+        We have added an ionScroll event on ionContent to check whether the infiniteScroll can be enabled or not by toggling the value of isScrollingEnabled whenever the height < 0.
       -->
     <ion-infinite-scroll
       @ionInfinite="loadMorePickers($event)"
       threshold="100px"
-      :disabled="!isScrollable"
-      :key="queryString"
+      v-show="isScrollingEnabled && isScrollable"
+      ref="infiniteScrollRef"
     >
       <ion-infinite-scroll-content
         loading-spinner="crescent"
@@ -108,7 +110,8 @@ export default defineComponent({
       selectedPicker: '',
       queryString: '',
       availablePickers: [],
-      isScrollable: true
+      isScrollable: true,
+      isScrollingEnabled: false
     }
   },
   methods: {
@@ -127,14 +130,25 @@ export default defineComponent({
         showToast(translate('Select a picker'))
       }
     },
+    enableScrolling() {
+      const parentElement = (this).$refs.contentRef.$el
+      const scrollEl = parentElement.shadowRoot.querySelector("main[part='scroll']")
+      let scrollHeight = scrollEl.scrollHeight, infiniteHeight = (this).$refs.infiniteScrollRef.$el.offsetHeight, scrollTop = scrollEl.scrollTop, threshold = 100, height = scrollEl.offsetHeight
+      const distanceFromInfinite = scrollHeight - infiniteHeight - scrollTop - threshold - height
+      if(distanceFromInfinite < 0) {
+        this.isScrollingEnabled = false;
+      } else {
+        this.isScrollingEnabled = true;
+      }
+    },
     async loadMorePickers(event) {
       this.getPicker(
         undefined,
         Math.ceil(
           this.availablePickers.length / (process.env.VUE_APP_VIEW_SIZE)
         ).toString()
-      ).then(() => {
-        event.target.complete();
+      ).then(async () => {
+        await event.target.complete();
       });
     },
     async getPicker(vSize, vIndex) {
@@ -200,6 +214,9 @@ export default defineComponent({
   async mounted() {
     // getting picker information on initial load
     await this.getPicker();
+  },
+  async ionViewWillEnter() {
+    this.isScrollingEnabled = false;
   },
   setup() {
     const store = useStore();

--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -29,6 +29,7 @@
       @ionInfinite="loadMorePickers($event)"
       threshold="100px"
       :disabled="!isScrollable"
+      :key="queryString"
     >
       <ion-infinite-scroll-content
         loading-spinner="crescent"

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -5,7 +5,7 @@
         <ion-title>{{ translate("Catalog") }}</ion-title>
       </ion-toolbar>
     </ion-header>
-    <ion-content>
+    <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()">
       <ion-searchbar @ionFocus="selectSearchBarText($event)" v-model="queryString" @keypress.enter="queryString = $event.target.value; getProducts()" />
       <main v-if="products.list.length">
         <ion-card button v-for="product in products.list" :key="product.productId"  @click="viewProduct(product)">
@@ -24,8 +24,8 @@
       <ion-infinite-scroll
         @ionInfinite="loadMoreProducts($event)"
         threshold="100px"
-        :disabled="!isScrollable"
-        :key="queryString"
+        v-show="isScrollingEnabled && isScrollable"
+        ref="infiniteScrollRef"
       >
         <ion-infinite-scroll-content
           loading-spinner="crescent"
@@ -74,6 +74,7 @@ export default defineComponent({
   data() {
     return {
       queryString: "",
+      isScrollingEnabled: false
     };
   },
   computed: {
@@ -83,14 +84,25 @@ export default defineComponent({
     }),
   },
   methods: {
+    enableScrolling() {
+      const parentElement = (this as any).$refs.contentRef.$el
+      const scrollEl = parentElement.shadowRoot.querySelector("main[part='scroll']")
+      let scrollHeight = scrollEl.scrollHeight, infiniteHeight = (this as any).$refs.infiniteScrollRef.$el.offsetHeight, scrollTop = scrollEl.scrollTop, threshold = 100, height = scrollEl.offsetHeight
+      const distanceFromInfinite = scrollHeight - infiniteHeight - scrollTop - threshold - height
+      if(distanceFromInfinite < 0) {
+        this.isScrollingEnabled = false;
+      } else {
+        this.isScrollingEnabled = true;
+      }
+    },
     async loadMoreProducts(event: any) {
       this.getProducts(
         undefined,
         Math.ceil(
           this.products.list?.length / (process.env.VUE_APP_VIEW_SIZE as any)
         ).toString()
-      ).then(() => {
-        event.target.complete();
+      ).then(async () => {
+        await event.target.complete();
       });
     },
     async getProducts(vSize?: any, vIndex?: any) {
@@ -116,6 +128,7 @@ export default defineComponent({
   },
 
   async ionViewWillEnter() {
+    this.isScrollingEnabled = false;
     this.queryString = this.products.queryString;
     this.getProducts();
   },

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -25,6 +25,7 @@
         @ionInfinite="loadMoreProducts($event)"
         threshold="100px"
         :disabled="!isScrollable"
+        :key="queryString"
       >
         <ion-infinite-scroll-content
           loading-spinner="crescent"

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -157,7 +157,9 @@
       <ion-refresher slot="fixed" @ionRefresh="refreshOrders($event)">
         <ion-refresher-content pullingIcon="crescent" refreshingSpinner="crescent" />
       </ion-refresher>
-      <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" :disabled="segmentSelected === 'open' ? !isOpenOrdersScrollable : segmentSelected === 'packed' ? !isPackedOrdersScrollable : !isCompletedOrdersScrollable">
+      <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" 
+        :disabled="segmentSelected === 'open' ? !isOpenOrdersScrollable : segmentSelected === 'packed' ? !isPackedOrdersScrollable : !isCompletedOrdersScrollable"
+        :key="queryString">
         <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')" />
       </ion-infinite-scroll>
     </ion-content>
@@ -404,6 +406,7 @@ export default defineComponent({
       }
     },
     async searchOrders() {
+      console.log('serach', this.queryString);
       if(this.segmentSelected === 'open') {
         this.getPickupOrders()
       } else if(this.segmentSelected === 'packed') {

--- a/src/views/ShipToStoreOrders.vue
+++ b/src/views/ShipToStoreOrders.vue
@@ -20,7 +20,7 @@
         </ion-segment>
       </div>    
     </ion-header>
-    <ion-content>
+    <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()">
       <div v-if="segmentSelected === 'incoming'">
         <div v-for="(order, index) in incomingOrders" :key="index" v-show="order.items.length">
           <ion-card button>
@@ -91,8 +91,8 @@
         <ion-refresher-content pullingIcon="crescent" refreshingSpinner="crescent" />
       </ion-refresher>
       <ion-infinite-scroll @ionInfinite="loadMoreOrders($event)" threshold="100px" 
-        :disabled="segmentSelected === 'incoming' ? !isIncomingOrdersScrollable : segmentSelected === 'readyForPickup' ? !isReadyForPickupOrdersScrollable : !isCompletedOrdersScrollable"
-        :key="queryString">
+        v-show="isScrollingEnabled && (segmentSelected === 'incoming' ? isIncomingOrdersScrollable : segmentSelected === 'readyForPickup' ? isReadyForPickupOrdersScrollable : isCompletedOrdersScrollable)"
+        ref="infiniteScrollRef">
         <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')" />
       </ion-infinite-scroll>
     </ion-content>
@@ -180,7 +180,8 @@ export default defineComponent({
   },
   data() {
     return {
-      queryString: ''
+      queryString: '',
+      isScrollingEnabled: false
     }
   },
   methods: {
@@ -214,28 +215,39 @@ export default defineComponent({
 
       await this.store.dispatch("order/getShipToStoreCompletedOrders", { viewSize, viewIndex, queryString: this.queryString, facilityId: this.currentFacility.facilityId });
     },
+    enableScrolling() {
+      const parentElement = (this as any).$refs.contentRef.$el
+      const scrollEl = parentElement.shadowRoot.querySelector("main[part='scroll']")
+      let scrollHeight = scrollEl.scrollHeight, infiniteHeight = (this as any).$refs.infiniteScrollRef.$el.offsetHeight, scrollTop = scrollEl.scrollTop, threshold = 100, height = scrollEl.offsetHeight
+      const distanceFromInfinite = scrollHeight - infiniteHeight - scrollTop - threshold - height
+      if(distanceFromInfinite < 0) {
+        this.isScrollingEnabled = false;
+      } else {
+        this.isScrollingEnabled = true;
+      }
+    },
     async loadMoreOrders (event: any) {
       if (this.segmentSelected === 'incoming') {
         this.getIncomingOrders(
           undefined,
           Math.ceil(this.incomingOrders.length / process.env.VUE_APP_VIEW_SIZE).toString()
-        ).then(() => {
-          event.target.complete();
-        })
+        ).then(async () => {
+          await event.target.complete();
+        });
       } else if (this.segmentSelected === 'packed') {
         this.getReadyForPickupOrders(
           undefined,
           Math.ceil(this.readyForPickupOrders.length / process.env.VUE_APP_VIEW_SIZE).toString()
-        ).then(() => {
-          event.target.complete();
-        })
+        ).then(async () => {
+          await event.target.complete();
+        });
       } else {
         this.getCompletedOrders(
           undefined,
           Math.ceil(this.completedOrders.length / process.env.VUE_APP_VIEW_SIZE).toString()
-        ).then(() => {
-          event.target.complete();
-        })
+        ).then(async () => {
+          await event.target.complete();
+        });
       }
     },
     segmentChanged (event: CustomEvent) {
@@ -391,6 +403,7 @@ export default defineComponent({
     },
   },
   ionViewWillEnter() {
+    this.isScrollingEnabled = false;
     this.queryString = '';
     if (this.segmentSelected === 'incoming') {
       this.getIncomingOrders()

--- a/src/views/ShipToStoreOrders.vue
+++ b/src/views/ShipToStoreOrders.vue
@@ -90,7 +90,9 @@
       <ion-refresher slot="fixed" @ionRefresh="refreshOrders($event)">
         <ion-refresher-content pullingIcon="crescent" refreshingSpinner="crescent" />
       </ion-refresher>
-      <ion-infinite-scroll @ionInfinite="loadMoreOrders($event)" threshold="100px" :disabled="segmentSelected === 'incoming' ? !isIncomingOrdersScrollable : segmentSelected === 'readyForPickup' ? !isReadyForPickupOrdersScrollable : !isCompletedOrdersScrollable">
+      <ion-infinite-scroll @ionInfinite="loadMoreOrders($event)" threshold="100px" 
+        :disabled="segmentSelected === 'incoming' ? !isIncomingOrdersScrollable : segmentSelected === 'readyForPickup' ? !isReadyForPickupOrdersScrollable : !isCompletedOrdersScrollable"
+        :key="queryString">
         <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')" />
       </ion-infinite-scroll>
     </ion-content>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

https://github.com/hotwax/dxp-components/issues/289
### Short Description and Why It's Useful
Removed the logic to re-render the infinite-scroll on queryString check that has been added in the previous PR.

Added a variable to check whether the scrolling can be enabled or not whenever users lands on the list page. For this, we have determined the height of the content part scroll and infiniteScroll component and if the height is less than 0 then only enabling the infinite-scroll component

Removed disabled as once the infiniteScroll is disabled it does not gets enabled again, hence removed the disabled property and instead used v-show to enable/disable infinite scroll.







### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
