### PR TITLE
Fixed: Infinite scroll with searchbar and loading bug

### DIFF
--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -37,7 +37,7 @@
     <ion-infinite-scroll
       @ionInfinite="loadMorePickers($event)"
       threshold="100px"
-      v-show="isScrollingEnabled && isScrollable"
+      v-show="isScrollable"
       ref="infiniteScrollRef"
     >
       <ion-infinite-scroll-content
@@ -142,6 +142,10 @@ export default defineComponent({
       }
     },
     async loadMorePickers(event) {
+      // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
+      if(!(this.isScrollingEnabled && this.isScrollable)) {
+          await event.target.complete();
+        }
       this.getPicker(
         undefined,
         Math.ceil(

--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -144,8 +144,8 @@ export default defineComponent({
     async loadMorePickers(event) {
       // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
       if(!(this.isScrollingEnabled && this.isScrollable)) {
-          await event.target.complete();
-        }
+        await event.target.complete();
+      }
       this.getPicker(
         undefined,
         Math.ceil(

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -24,7 +24,7 @@
       <ion-infinite-scroll
         @ionInfinite="loadMoreProducts($event)"
         threshold="100px"
-        v-show="isScrollingEnabled && isScrollable"
+        v-show="isScrollable"
         ref="infiniteScrollRef"
       >
         <ion-infinite-scroll-content
@@ -96,6 +96,10 @@ export default defineComponent({
       }
     },
     async loadMoreProducts(event: any) {
+      // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
+      if(!(this.isScrollingEnabled && this.isScrollable)) {
+        await event.target.complete();
+      }
       this.getProducts(
         undefined,
         Math.ceil(

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -355,7 +355,6 @@ export default defineComponent({
       // Added this check here as if added on infinite-scroll component the Loading content does not get displayed
       if (!(this.isScrollingEnabled && (this.segmentSelected === 'open' ? this.isOpenOrdersScrollable : this.segmentSelected === 'packed' ? this.isPackedOrdersScrollable : this.isCompletedOrdersScrollable))) {
         await event.target.complete();
-        return;
       }
       if (this.segmentSelected === 'open') {
         this.getPickupOrders(

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -158,7 +158,7 @@
         <ion-refresher-content pullingIcon="crescent" refreshingSpinner="crescent" />
       </ion-refresher>
       <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" 
-        v-show="isScrollingEnabled && (segmentSelected === 'open' ? isOpenOrdersScrollable : segmentSelected === 'packed' ? isPackedOrdersScrollable : isCompletedOrdersScrollable)"
+        v-show="(segmentSelected === 'open' ? isOpenOrdersScrollable : segmentSelected === 'packed' ? isPackedOrdersScrollable : isCompletedOrdersScrollable)"
         ref="infiniteScrollRef">
         <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')" />
       </ion-infinite-scroll>
@@ -352,6 +352,11 @@ export default defineComponent({
       }
     },
     async loadMoreProducts (event: any) {
+      // Added this check here as if added on infinite-scroll component the Loading content does not get displayed
+      if (!(this.isScrollingEnabled && (this.segmentSelected === 'open' ? this.isOpenOrdersScrollable : this.segmentSelected === 'packed' ? this.isPackedOrdersScrollable : this.isCompletedOrdersScrollable))) {
+        await event.target.complete();
+        return;
+      }
       if (this.segmentSelected === 'open') {
         this.getPickupOrders(
           undefined,

--- a/src/views/ShipToStoreOrders.vue
+++ b/src/views/ShipToStoreOrders.vue
@@ -91,7 +91,7 @@
         <ion-refresher-content pullingIcon="crescent" refreshingSpinner="crescent" />
       </ion-refresher>
       <ion-infinite-scroll @ionInfinite="loadMoreOrders($event)" threshold="100px" 
-        v-show="isScrollingEnabled && (segmentSelected === 'incoming' ? isIncomingOrdersScrollable : segmentSelected === 'readyForPickup' ? isReadyForPickupOrdersScrollable : isCompletedOrdersScrollable)"
+        v-show="(segmentSelected === 'incoming' ? isIncomingOrdersScrollable : segmentSelected === 'readyForPickup' ? isReadyForPickupOrdersScrollable : isCompletedOrdersScrollable)"
         ref="infiniteScrollRef">
         <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')" />
       </ion-infinite-scroll>
@@ -227,6 +227,10 @@ export default defineComponent({
       }
     },
     async loadMoreOrders (event: any) {
+      // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
+      if (!(this.isScrollingEnabled && (this.segmentSelected === 'incoming' ? this.isIncomingOrdersScrollable : this.segmentSelected === 'readyForPickup' ? this.isReadyForPickupOrdersScrollable : this.isCompletedOrdersScrollable))) {
+        await event.target.complete();
+      }
       if (this.segmentSelected === 'incoming') {
         this.getIncomingOrders(
           undefined,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

https://github.com/hotwax/dxp-components/issues/289

### Short Description and Why It's Useful
Removed the logic to re-render the infinite-scroll on queryString check that has been added in the previous PR.

Added a variable to check whether the scrolling can be enabled or not whenever users lands on the list page. For this, we have determined the height of the content part scroll and infiniteScroll component and if the height is less than 0 then only enabling the infinite-scroll component

Removed disabled as once the infiniteScroll is disabled it does not gets enabled again, hence removed the disabled property and instead used v-show to enable/disable infinite scroll.


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
