### PR TITLE
Fixed: Allowed search on groupName to handle the case where picker is a party group(#389)

### DIFF
--- a/src/components/EditPickerModal.vue
+++ b/src/components/EditPickerModal.vue
@@ -128,7 +128,7 @@ export default defineComponent({
           groupName_value: this.queryString,
           groupName_op: 'contains',
           groupName_ic: 'Y',
-          groupName_grp: '3'
+          groupName_grp: '4'
         }
       }
 
@@ -143,14 +143,14 @@ export default defineComponent({
         orderBy: "firstName ASC",
         filterByDate: "Y",
         distinct: "Y",
-        fieldList: ["firstName", "lastName", "partyId"]
+        fieldList: ["firstName", "lastName", "partyId", "groupName"]
       }
       
       try {
         const resp = await PicklistService.getAvailablePickers(payload);
         if (resp.status === 200 && !hasError(resp)) {
           this.availablePickers = resp.data.docs.map((picker: any) => ({
-            name: picker.firstName + ' ' + picker.lastName,
+            name: picker.firstName || picker.lastName ? `${picker.firstName} ${picker.lastName}` : picker.groupName,
             id: picker.partyId
           }))
         } else {

--- a/src/components/EditPickerModal.vue
+++ b/src/components/EditPickerModal.vue
@@ -125,6 +125,10 @@ export default defineComponent({
           partyId_op: 'contains',
           partyId_ic: 'Y',
           partyId_grp: '3',
+          groupName_value: this.queryString,
+          groupName_op: 'contains',
+          groupName_ic: 'Y',
+          groupName_grp: '3'
         }
       }
 

--- a/src/components/EditPickerModal.vue
+++ b/src/components/EditPickerModal.vue
@@ -150,7 +150,7 @@ export default defineComponent({
         const resp = await PicklistService.getAvailablePickers(payload);
         if (resp.status === 200 && !hasError(resp)) {
           this.availablePickers = resp.data.docs.map((picker: any) => ({
-            name: picker.firstName || picker.lastName ? `${picker.firstName} ${picker.lastName}` : picker.groupName,
+            name: picker.groupName ? picker.groupName : `${picker.firstName} ${picker.lastName}`,  
             id: picker.partyId
           }))
         } else {

--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -203,7 +203,7 @@ export default defineComponent({
       
       try {
         resp = await PicklistService.getAvailablePickers(payload);
-        if (resp.status === 200 && !hasError(resp) && resp.data.count > 0) {
+        if (resp.status === 200 && !hasError(resp) && resp.data.docs.length > 0) {
           const pickers = resp.data.docs.map((picker) => ({
             name: picker.firstName || picker.lastName ? `${picker.firstName} ${picker.lastName}` : picker.groupName,
             id: picker.partyId

--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -180,7 +180,7 @@ export default defineComponent({
           groupName_value: this.queryString,
           groupName_op: 'contains',
           groupName_ic: 'Y',
-          groupName_grp: '3'
+          groupName_grp: '5'
         }
       }
 
@@ -196,7 +196,7 @@ export default defineComponent({
         orderBy: "firstName ASC",
         filterByDate: "Y",
         distinct: "Y",
-        fieldList: ["firstName", "lastName", "partyId"]
+        fieldList: ["firstName", "lastName", "partyId", "groupName"]
       }
       let resp;
       let total = 0;
@@ -205,7 +205,7 @@ export default defineComponent({
         resp = await PicklistService.getAvailablePickers(payload);
         if (resp.status === 200 && !hasError(resp) && resp.data.count > 0) {
           const pickers = resp.data.docs.map((picker) => ({
-            name: picker.firstName+ ' ' +picker.lastName,
+            name: picker.firstName || picker.lastName ? `${picker.firstName} ${picker.lastName}` : picker.groupName,
             id: picker.partyId
           }))
           this.availablePickers = this.availablePickers.concat(pickers);

--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -177,6 +177,10 @@ export default defineComponent({
           partyId_op: 'contains',
           partyId_ic: 'Y',
           partyId_grp: '4',
+          groupName_value: this.queryString,
+          groupName_op: 'contains',
+          groupName_ic: 'Y',
+          groupName_grp: '3'
         }
       }
 

--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -205,7 +205,7 @@ export default defineComponent({
         resp = await PicklistService.getAvailablePickers(payload);
         if (resp.status === 200 && !hasError(resp) && resp.data.docs.length > 0) {
           const pickers = resp.data.docs.map((picker) => ({
-            name: picker.firstName || picker.lastName ? `${picker.firstName} ${picker.lastName}` : picker.groupName,
+            name: picker.groupName ? picker.groupName : `${picker.firstName} ${picker.lastName}`,  
             id: picker.partyId
           }))
           this.availablePickers = this.availablePickers.concat(pickers);


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#389 
### Short Description and Why It's Useful
- Update the `payload` of the function which is responsible for searching.
- Added properties related to `group` and mention the number of fields in which the searching should perform. 

### Screenshots of Visual Changes before/after (If There Are Any)
![Screenshot from 2024-04-30 12-32-38](https://github.com/hotwax/bopis/assets/89250683/94df4e4c-e771-47bf-9d95-90b4fc050d6e)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
