### PR TITLE
Improved: logic to show inventory computation of other shipment items in an order (#396)

### DIFF
--- a/src/components/ProductListItem.vue
+++ b/src/components/ProductListItem.vue
@@ -4,7 +4,7 @@
       <DxpShopifyImg :src="getProduct(item.productId).mainImageUrl" size="small" />
     </ion-thumbnail>
     <ion-label class="ion-text-wrap">
-      <h2>{{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) }}</h2>
+      <h2>{{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) : getProduct(item.productId).productName }}</h2>
       <p class="ion-text-wrap">{{ getProductIdentificationValue(productIdentificationPref.secondaryId, getProduct(item.productId)) }}</p>
     </ion-label>
     <!-- Only show stock if its not a ship to store order -->

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -312,6 +312,20 @@ const actions: ActionTree<OrderState , RootState> ={
     await dispatch('fetchShipGroupForOrder');
   },
 
+  async updateOrderItemFetchingStatus ({ commit, state }, payload) {
+    const order = state.current ? JSON.parse(JSON.stringify(state.current)) : {};
+
+    order.shipGroups?.find((shipGroup: any) => {
+      if(shipGroup.shipGroupSeqId === payload.shipGroupSeqId){
+        shipGroup.items?.find((item: any) => {
+          if(item.productId === payload.productId) item.isFetchingStock = !item.isFetchingStock
+        });
+      }
+    })
+
+    commit(types.ORDER_CURRENT_UPDATED, { order })
+  },
+
   async getPackedOrders ({ commit, state }, payload) {
     // Show loader only when new query and not the infinite scroll
     if (payload.viewIndex === 0) emitter.emit("presentLoader");
@@ -1122,6 +1136,8 @@ const actions: ActionTree<OrderState , RootState> ={
       const reservedShipGroupForOrder = shipGroups.find((group: any) => shipGroup.shipGroupSeqId === group.doclist?.docs[0]?.shipGroupSeqId)
 
       const reservedShipGroup = reservedShipGroupForOrder?.groupValue ? reservedShipGroupForOrder.doclist.docs[0] : ''
+
+      reservedShipGroupForOrder.doclist.docs.map((item: any) => item.isFetchingStock = false);
 
       return reservedShipGroup ? {
         ...shipGroup,

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -154,11 +154,9 @@
                     <ion-thumbnail slot="start">
                       <DxpShopifyImg :src="getProduct(item.productId).mainImageUrl" size="small"/>
                     </ion-thumbnail>
-                    <ion-label>
-                      <p class="overline">{{ getProductIdentificationValue(productIdentificationPref.secondaryId, getProduct(item.productId)) }}</p>
-                      {{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) : getProduct(item.productId).productName }}
-                      <p>{{ translate("Color:", { color: getFeature(getProduct(item.productId).featureHierarchy, '1/COLOR') }) }}</p>
-                      <p>{{ translate("Size:", { size: getFeature(getProduct(item.productId).featureHierarchy, '1/SIZE') }) }}</p>
+                    <ion-label class="ion-text-wrap">
+                      <h2>{{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) : getProduct(item.productId).productName }}</h2>
+                      <p class="ion-text-wrap">{{ getProductIdentificationValue(productIdentificationPref.secondaryId, getProduct(item.productId)) }}</p>
                     </ion-label>
 
                     <div slot="end">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#396

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Displayed inventory computation for the items in other shipments of an order.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2024-06-17 12-05-56](https://github.com/hotwax/bopis/assets/69574321/581e2aba-7f9d-4073-9cf3-64dc828243ae)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
