### PR TITLE
Improved: clearing user preference state on logout, showShippingOrder set to false by default (#395)

### DIFF
--- a/src/store/modules/user/index.ts
+++ b/src/store/modules/user/index.ts
@@ -13,7 +13,7 @@ const userModule: Module<UserState, RootState> = {
       currentFacility: {},
       instanceUrl: '',
       preference: {
-        showShippingOrders: true,
+        showShippingOrders: false,
         showPackingSlip: false,
         configurePicker: false
       },

--- a/src/store/modules/user/mutations.ts
+++ b/src/store/modules/user/mutations.ts
@@ -11,6 +11,11 @@ const mutations: MutationTree <UserState> = {
       state.current = {}
       state.currentFacility = {}
       state.permissions = []
+      state.preference= {
+        showShippingOrders: false,
+        showPackingSlip: false,
+        configurePicker: false
+      }
     },
     [types.USER_INFO_UPDATED] (state, payload) {
         state.current = payload


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#395

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Clearing preference state on logout.
- Made showShippingOrder to false by default.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
