### PR TITLE
Improved: logic to append isFetchingStock to false by default in shipGroup items (#403)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -1137,8 +1137,6 @@ const actions: ActionTree<OrderState , RootState> ={
 
       const reservedShipGroup = reservedShipGroupForOrder?.groupValue ? reservedShipGroupForOrder.doclist.docs[0] : ''
 
-      reservedShipGroupForOrder.doclist.docs.map((item: any) => item.isFetchingStock = false);
-
       return reservedShipGroup ? {
         ...shipGroup,
         items: reservedShipGroupForOrder.doclist.docs,
@@ -1149,6 +1147,10 @@ const actions: ActionTree<OrderState , RootState> ={
         ...shipGroup,
         category: getOrderCategory(shipGroup.items[0])
       }
+    })
+
+    shipGroups.map((shipGroup: any) => {
+      shipGroup.items.map((item: any) => item.isFetchingStock = false);
     })
 
     const carrierPartyIds: Array<string> = [];


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#403

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved logic to appending isFetchingStock by default to false in all shipGroup items

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
