### PR TITLE
Improved: changing the state of notification preference toggle only if api success (#405)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -324,7 +324,7 @@ const actions: ActionTree<UserState, RootState> = {
   },
 
   async updateNotificationPreferences({ commit }, payload) {
-      commit(types.USER_NOTIFICATIONS_PREFERENCES_UPDATED, payload)
+    commit(types.USER_NOTIFICATIONS_PREFERENCES_UPDATED, payload)
   },
 
   async storeClientRegistrationToken({ commit }, registrationToken) {

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -323,6 +323,10 @@ const actions: ActionTree<UserState, RootState> = {
     }
   },
 
+  async updateNotificationPreferences({ commit }, payload) {
+      commit(types.USER_NOTIFICATIONS_PREFERENCES_UPDATED, payload)
+  },
+
   async storeClientRegistrationToken({ commit }, registrationToken) {
     const firebaseDeviceId = generateDeviceId()
     commit(types.USER_FIREBASE_DEVICEID_UPDATED, firebaseDeviceId)

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -167,7 +167,7 @@
           </ion-card-content>
           <ion-list>
             <ion-item :key="pref.enumId" v-for="pref in notificationPrefs" lines="none">
-              <ion-toggle label-placement="start" @click="confirmNotificationPrefUpdate(pref.enumId, $event)" :checked="pref.isEnabled">{{ pref.description }}</ion-toggle>
+              <ion-toggle label-placement="start" @click.prevent="confirmNotificationPrefUpdate(pref.enumId, $event)" :checked="pref.isEnabled">{{ pref.description }}</ion-toggle>
             </ion-item>
           </ion-list>
         </ion-card>
@@ -421,12 +421,8 @@ export default defineComponent({
         emitter.emit('presentLoader',  { backdropDismiss: false })
         const facilityId = (this.currentFacility as any).facilityId
         const topicName = generateTopicName(facilityId, enumId)
-        // event.target.checked returns the initial value (the value that was there before clicking
-        // and updating the toggle). But it returns the updated value on further references (if passed
-        // as a parameter in other function, here in our case, passed from confirmNotificationPrefUpdate)
-        // Hence, event.target.checked here holds the updated value (value after the toggle action)
-        const notificationPref = this.notificationPrefs.find((pref: any) => pref.enumId === enumId)
 
+        const notificationPref = this.notificationPrefs.find((pref: any) => pref.enumId === enumId)
         notificationPref.isEnabled
           ? await unsubscribeTopic(topicName, process.env.VUE_APP_NOTIF_APP_ID)
           : await subscribeTopic(topicName, process.env.VUE_APP_NOTIF_APP_ID)
@@ -435,17 +431,12 @@ export default defineComponent({
         await this.store.dispatch('user/updateNotificationPreferences', this.notificationPrefs)
         showToast(translate('Notification preferences updated.'))
       } catch (error) {
-        // reverting the value of toggle as event.target.checked is 
-        // updated on click event, and revert is needed on API fail
-        event.target.checked = !event.target.checked;
         showToast(translate('Notification preferences not updated. Please try again.'))
       } finally {
         emitter.emit("dismissLoader")
       }
     },
-    async confirmNotificationPrefUpdate(enumId: string, event: any) {
-      // To stop event bubbling when clicking on the toggle
-      event.preventDefault()
+    async confirmNotificationPrefUpdate(enumId: string, event: CustomEvent) {
       event.stopImmediatePropagation();
 
       const message = translate("Are you sure you want to update the notification preferences?");

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -416,7 +416,7 @@ export default defineComponent({
       }
       await this.store.dispatch('user/updatePartialOrderRejectionConfig', params)
     },
-    async updateNotificationPref(enumId: string, event: any) {
+    async updateNotificationPref(enumId: string) {
       try {
         emitter.emit('presentLoader',  { backdropDismiss: false })
         const facilityId = (this.currentFacility as any).facilityId
@@ -453,7 +453,7 @@ export default defineComponent({
             handler: async () => {
               // passing event reference for updation in case the API success
               alertController.dismiss()
-              await this.updateNotificationPref(enumId, event)
+              await this.updateNotificationPref(enumId)
             }
           }
         ],


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#405

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved notification preferences updation logic so as to change toggle state only if preference updates successfully.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
