### PR TITLE
Improved: ripple effect now show on the entire ion-card(#416)

### DIFF
--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -513,6 +513,9 @@ export default defineComponent({
 </script>
 
 <style scoped>
+ion-item {
+  --background: transparent;
+}
 
 @media (min-width: 343px) {
   ion-content > div {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#416 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- When an `ion-item` element is added inside an ion-card, it creates a new layer on top of the card, and by default, the ion-item element has a background colour that covers the card, making it appear as though the ripple effect is not covering the entire card.
- Setting the background colour of the ion-item element to `transparent` within the ion-card allows the ripple effect to be visible underneath, creating the desired effect on the entire card.
- I took the reference from this github issue : https://github.com/ionic-team/ionic-framework/issues/21210

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[3fb32fa5-12c7-46cd-9256-59a1ae71e337.webm](https://github.com/user-attachments/assets/a7cb5e01-7368-4587-b09e-a178e09d9aba)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
