### PR TITLE
Improved: logic to calculate derived status for order ship group and added check for displaying pending allocation as default category(#410)

### DIFF
--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -118,6 +118,7 @@
   "Packing slips help customer reconcile their order against the delivered items.": "内容明細票はお客様が注文と配送された商品を確認（照合）する際に役立ちます。",
   "Partial Order rejection": "部分的な注文拒否",
   "Password": "パスワード",
+  "Pending allocation": "Pending allocation",
   "pending approval": "承認待ち",
   "Picked by": "{pickers} によってピックアップされました",
   "Pick up location": "受取場所",

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -1134,7 +1134,6 @@ const actions: ActionTree<OrderState , RootState> ={
 
     shipGroups = payload.shipGroups.map((shipGroup: any) => {
       const reservedShipGroupForOrder = shipGroups.find((group: any) => shipGroup.shipGroupSeqId === group.doclist?.docs[0]?.shipGroupSeqId)
-
       const reservedShipGroup = reservedShipGroupForOrder?.groupValue ? reservedShipGroupForOrder.doclist.docs[0] : ''
 
       return reservedShipGroup ? {
@@ -1142,7 +1141,7 @@ const actions: ActionTree<OrderState , RootState> ={
         items: reservedShipGroupForOrder.doclist.docs,
         carrierPartyId: reservedShipGroup.carrierPartyId,
         shipmentId: reservedShipGroup.shipmentId,
-        category: getOrderCategory(reservedShipGroupForOrder.doclist.docs[0])
+        category: getOrderCategory({ ...reservedShipGroupForOrder.doclist.docs[0], ...shipGroup.items[0] }) // Passing shipGroup item information as we need to derive the order status and for that we need some properties those are available on ORDER doc
       } : {
         ...shipGroup,
         category: getOrderCategory(shipGroup.items[0])

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -78,7 +78,7 @@ const getOrderCategory = (order: any) => {
     const paramKeys = Object.keys(parameters)
     // used every as to check against each filtering property
     
-    // Added check for property value *, as we add * as value when operator NOT is defined and also for * values we want to just check for whether the property exist or not
+    // Added check for property value *, as we will add * as value when operator NOT is defined and also for * values we do not want to check for property existence directly on order
     const isMatched = paramKeys.every((key: string) => (parameters[key].value === "*" || Object.prototype.hasOwnProperty.call(order, key)) && handleParameterMatching(order[key], parameters[key].value, parameters[key]['OP']))
 
     // return the value when all params matched for an order

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -1,9 +1,7 @@
+import store from "@/store"
+
 const orderCategoryParameters = {
   'Open': {
-    'shipmentMethodTypeId': {
-      'value': 'STOREPICKUP',
-      'OP': 'NOT'
-    },
     'shipmentStatusId': {
       'value': '*',
       'OP': 'NOT',
@@ -20,10 +18,6 @@ const orderCategoryParameters = {
     }
   },
   'Packed': {
-    'shipmentMethodTypeId': {
-      'value': 'STOREPICKUP',
-      'OP': 'NOT'
-    },
     'shipmentStatusId': {
       'value': 'SHIPMENT_PACKED',
     },
@@ -36,10 +30,6 @@ const orderCategoryParameters = {
     },
   },
   'Completed': {
-    'shipmentMethodTypeId': {
-      'value': 'STOREPICKUP',
-      'OP': 'NOT'
-    },
     'orderItemStatusId': {
       'value': 'ITEM_COMPLETED'
     },
@@ -50,7 +40,7 @@ const orderCategoryParameters = {
       'value': 'ORDER'
     }
   }
-}
+} as any
 
 const handleParameterMatching = (orderVal: any, parameterVal: any, operation?: string) => {
   // considering params will always be an Array for ORing and ANDing
@@ -73,6 +63,13 @@ const handleParameterMatching = (orderVal: any, parameterVal: any, operation?: s
 }
 
 const getOrderCategory = (order: any) => {
+
+  if(!store.state.user.preference.showShippingOrders) {
+    orderCategoryParameters["Open"]["shipmentMethodTypeId"] = { value: "STOREPICKUP" }
+    orderCategoryParameters["Packed"]["shipmentMethodTypeId"] = { value: "STOREPICKUP" }
+    orderCategoryParameters["Completed"]["shipmentMethodTypeId"] = { value: "STOREPICKUP" }
+  }
+
   const orderCategoryParameterEntries = Object.entries(orderCategoryParameters)
   let result = ''
   // using find, as once any of the category is matched then return from here;
@@ -81,7 +78,8 @@ const getOrderCategory = (order: any) => {
     const paramKeys = Object.keys(parameters)
     // used every as to check against each filtering property
     
-    const isMatched = paramKeys.every((key: string) => Object.prototype.hasOwnProperty.call(order, key) && handleParameterMatching(order[key], parameters[key].value, parameters[key]['OP']))
+    // Added check for property value *, as we add * as value when operator NOT is defined and also for * values we want to just check for whether the property exist or not
+    const isMatched = paramKeys.every((key: string) => (parameters[key].value === "*" || Object.prototype.hasOwnProperty.call(order, key)) && handleParameterMatching(order[key], parameters[key].value, parameters[key]['OP']))
 
     // return the value when all params matched for an order
     if (isMatched) {

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -134,7 +134,7 @@
                       <ion-card-title>{{ shipGroup.facilityName }}</ion-card-title>
                       {{ shipGroup.shipGroupSeqId }}
                     </div>
-                    <ion-badge :color="shipGroup.category ? 'primary' : 'medium'">{{ shipGroup.category ? shipGroup.category : '-' }}</ion-badge>
+                    <ion-badge :color="shipGroup.category ? 'primary' : 'medium'">{{ shipGroup.category ? shipGroup.category : translate('Pending allocation') }}</ion-badge>
                   </ion-card-header>
         
                   <ion-item v-if="shipGroup.carrierPartyId">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#410 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Improved check when deriving status for shipGroup
- Added support to derive status for non pickup orders as well

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
