### PR TITLE
Improved: logic to show rejection reason options based on admin permission (#438)

### DIFF
--- a/src/components/OrderItemRejHistoryModal.vue
+++ b/src/components/OrderItemRejHistoryModal.vue
@@ -92,7 +92,8 @@ export default defineComponent({
       modalController.dismiss({ dismissed: true });
     },
     getRejectReasonDescription(rejectReasonEnumId: string) {
-      return this.rejectReasons.find((reason: any) => reason.enumId === rejectReasonEnumId)?.description;
+      const reason = this.rejectReasons.find((reason: any) => reason.enumId === rejectReasonEnumId)
+      return reason?.description ? reason.description : reason?.enumDescription;
     },
     getTime(time: number) {
       return time ? DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED) : ''

--- a/src/components/RejectOrderModal.vue
+++ b/src/components/RejectOrderModal.vue
@@ -17,7 +17,7 @@
       <ion-list-header>{{ translate("Select reason") }}</ion-list-header>
       <ion-radio-group v-model="rejectReasonId">
         <ion-item v-for="reason in rejectReasons" :key="reason.enumId">
-          <ion-radio :value="reason.enumId" label-placement="end" justify="start">{{ reason.description ? reason.description : reason.enumId }}</ion-radio>
+          <ion-radio :value="reason.enumId" label-placement="end" justify="start">{{ reason.description ? reason.description : reason.enumDescription ? reason.enumDescription : reason.enumId }}</ion-radio>
         </ion-item>
       </ion-radio-group>
     </ion-list>

--- a/src/components/ReportAnIssueModal.vue
+++ b/src/components/ReportAnIssueModal.vue
@@ -17,7 +17,7 @@
       <ion-list-header>{{ translate("Select reason") }}</ion-list-header>
       <ion-radio-group v-model="rejectReasonId">
         <ion-item v-for="reason in rejectReasons" :key="reason.enumId">
-          <ion-radio label-placement="end" justify="start" :value="reason.enumId">{{ reason.description ? reason.description : reason.enumId }}</ion-radio>
+          <ion-radio label-placement="end" justify="start" :value="reason.enumId">{{ reason.description ? reason.description : reason.enumDescription ? reason.enumDescription : reason.enumId }}</ion-radio>
         </ion-item>
       </ion-radio-group>
     </ion-list>

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -34,6 +34,7 @@ const actions: ActionTree<UtilState, RootState> = {
         "inputFields": {
           "enumerationGroupId": "BOPIS_REJ_RSN_GRP"
         },
+        // We should not fetch description here, as the description contains EnumGroup description which we don't want to show on UI.
         "fieldList": ["enumerationGroupId", "enumId", "sequenceNum", "enumDescription", "enumName"],
         "entityName": "EnumerationGroupAndMember",
         "filterByDate": "Y",

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -32,7 +32,7 @@ const actions: ActionTree<UtilState, RootState> = {
     } else {
       payload = {
         "inputFields": {
-          "enumerationGroupId": "FF_REJ_RSN_GRP"
+          "enumerationGroupId": "BOPIS_REJ_RSN_GRP"
         },
         "fieldList": ["enumerationGroupId", "enumId", "sequenceNum", "enumDescription", "enumName"],
         "entityName": "EnumerationGroupAndMember",


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#438

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Showing all rejection reasons only if user is admin else showing only the reasons from the bopis group.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
