### PR TITLE
Improved: showing ion spinner until picker list is being fetched (#444)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -46,6 +46,7 @@
   "Failed to update configuration": "Failed to update configuration",
   "Failed to print shipping label and packing slip": "Failed to print shipping label and packing slip",
   "Failed to update product store setting.": "Failed to update product store setting.",
+  "Fetching pickers": "Fetching pickers",
   "First name": "First name",
   "Generate packing slips": "Generate packing slips",
   "Generate shipping documents": "Generate shipping documents",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -44,6 +44,7 @@
   "Failed to update configuration": "No se pudo actualizar la configuración",
   "Failed to print shipping label and packing slip": "Error al imprimir la etiqueta de envío y la hoja de embalaje",
   "Failed to update product store setting.": "Failed to update product store setting.",
+  "Fetching pickers": "Fetching pickers",
   "First name": "Nombre",
   "Generate packing slips": "Generar documentos de embalaje",
   "Generate shipping documents": "Generar documentos de envío",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -44,6 +44,7 @@
   "Failed to update configuration": "設定の更新に失敗しました",
   "Failed to print shipping label and packing slip": "出荷ラベルと納品書の印刷に失敗しました。",
   "Failed to update product store setting.":"Failed to update product store setting.",
+  "Fetching pickers": "Fetching pickers",
   "First name": "名",
   "Generate packing slips": "内容明細票の作成",
   "Generate shipping documents": "出荷書類を生成する",

--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -13,7 +13,11 @@
   <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()">
     <ion-searchbar v-model="queryString" @keyup.enter="queryString = $event.target.value; searchPicker()"/>
 
-    <div class="ion-text-center ion-margin-top" v-if="!availablePickers.length">{{ translate('No picker found') }}</div>
+    <div v-if="isLoading" class="empty-state">
+      <ion-spinner name="crescent" />
+      <ion-label>{{ translate("Fetching pickers") }}</ion-label>
+    </div>
+    <div class="ion-text-center ion-margin-top" v-else-if="!availablePickers.length">{{ translate('No picker found') }}</div>
 
     <ion-list v-else>
       <ion-list-header>{{ translate("Staff") }}</ion-list-header>
@@ -64,11 +68,13 @@ import {
   IonHeader,
   IonIcon,
   IonItem,
+  IonLabel,
   IonList,
   IonListHeader,
   IonRadio,
   IonRadioGroup,
   IonSearchbar,
+  IonSpinner,
   IonTitle,
   IonToolbar,
   IonInfiniteScroll,
@@ -94,11 +100,13 @@ export default defineComponent({
     IonHeader,
     IonIcon,
     IonItem,
+    IonLabel,
     IonList,
     IonListHeader,
     IonRadio,
     IonRadioGroup,
     IonSearchbar,
+    IonSpinner,
     IonTitle,
     IonToolbar,
     IonInfiniteScroll,
@@ -111,7 +119,8 @@ export default defineComponent({
       queryString: '',
       availablePickers: [],
       isScrollable: true,
-      isScrollingEnabled: false
+      isScrollingEnabled: false,
+      isLoading: false
     }
   },
   methods: {
@@ -155,6 +164,7 @@ export default defineComponent({
       });
     },
     async getPicker(vSize, vIndex) {
+      this.isLoading = true;
       let inputFields = {}
 
       if(this.queryString.length > 0) {
@@ -216,6 +226,7 @@ export default defineComponent({
         logger.error(translate('Something went wrong'))
       }
       this.isScrollable = this.availablePickers.length < total;
+      this.isLoading = false;
     }
   },
   async mounted() {

--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -17,7 +17,7 @@
       <ion-spinner name="crescent" />
       <ion-label>{{ translate("Fetching pickers") }}</ion-label>
     </div>
-    <div class="ion-text-center ion-margin-top" v-else-if="!availablePickers.length">{{ translate('No picker found') }}</div>
+    <div class="empty-state" v-else-if="!availablePickers.length">{{ translate('No picker found') }}</div>
 
     <ion-list v-else>
       <ion-list-header>{{ translate("Staff") }}</ion-list-header>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#444

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Displaying spinner while api for fetching pickers is in progress for better user experience.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2024-10-21 15-12-45](https://github.com/user-attachments/assets/df7542fb-1fe2-494f-b2b2-7bbb2a66a917)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
