### PR TITLE
Fixed: stopped spinner to show on infinite scrolling (#444)

### DIFF
--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -164,7 +164,7 @@ export default defineComponent({
       });
     },
     async getPicker(vSize, vIndex) {
-      this.isLoading = true;
+      if(!vIndex) this.isLoading = true;
       let inputFields = {}
 
       if(this.queryString.length > 0) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#444

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Not showing spinner while fethcing picker using infinite scroll.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
