### PR TITLE
Improved: Added support for fetching the updated inventory in the Completed tab after the handover or ship of an order (#468)

### DIFF
--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -257,7 +257,8 @@ export default defineComponent({
       isCompletedOrdersScrollable: 'order/isCompletedOrdersScrollable',
       notifications: 'user/getNotifications',
       unreadNotificationsStatus: 'user/getUnreadNotificationsStatus',
-      getBopisProductStoreSettings: 'user/getBopisProductStoreSettings'
+      getBopisProductStoreSettings: 'user/getBopisProductStoreSettings',
+      getProductStock: 'stock/getProductStock',
     })
   },
   data() {
@@ -434,9 +435,22 @@ export default defineComponent({
     },
     async deliverShipment (order: any) {
       await this.store.dispatch('order/deliverShipment', order)
-      .then((resp) => {
+      .then(async (resp) => {
         if(!hasError(resp)){
           showToast(translate('Order delivered to', {customerName: order.customer.name}))
+
+          const productIds = [...new Set(order.parts.reduce((productId: any, part: any) => {
+            const ids = part.items.map((item: any) => item.productId)
+            return productId.concat(ids)
+          }, []))]
+
+          const fetchProductStock = productIds.map(async (productId: any) => {
+            const productStock = this.getProductStock(productId);
+            if (productStock && productStock.quantityOnHandTotal >= 0) {
+              return this.store.dispatch('stock/fetchStock', { productId })
+            }
+          })
+          await Promise.allSettled(fetchProductStock);
         }
       })
     },

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -435,8 +435,8 @@ export default defineComponent({
     },
     async deliverShipment (order: any) {
       await this.store.dispatch('order/deliverShipment', order)
-      .then(async (resp) => {
-        if(!hasError(resp)){
+      .then((resp) => {
+        if(!hasError(resp)) {
           showToast(translate('Order delivered to', {customerName: order.customer.name}))
 
           const productIds = [...new Set(order.parts.reduce((productId: any, part: any) => {
@@ -444,13 +444,12 @@ export default defineComponent({
             return productId.concat(ids)
           }, []))]
 
-          const fetchProductStock = productIds.map(async (productId: any) => {
+          productIds.map((productId: any) => {
             const productStock = this.getProductStock(productId);
             if (productStock && productStock.quantityOnHandTotal >= 0) {
-              return this.store.dispatch('stock/fetchStock', { productId })
+              this.store.dispatch('stock/fetchStock', { productId });
             }
           })
-          await Promise.allSettled(fetchProductStock);
         }
       })
     },

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -439,6 +439,8 @@ export default defineComponent({
         if(!hasError(resp)) {
           showToast(translate('Order delivered to', {customerName: order.customer.name}))
 
+          // We are collecting the product IDs of the order items and then fetching stock information
+          // for each product ID if it is available for updated inventory.
           const productIds = [...new Set(order.parts.reduce((productId: any, part: any) => {
             const ids = part.items.map((item: any) => item.productId)
             return productId.concat(ids)


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#468

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added support to fetch the updated inventory of the item in the order.
- It only runs when the user has already checked the QOH on any of the tabs from "Open" and "Packed."
- If the user directly checks the inventory on the "Completed" tab, it will show the updated inventory of the item.


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
