### PR TITLE
Improved: settings page icon in tabbar to use outline type icon

### DIFF
--- a/src/views/Tabs.vue
+++ b/src/views/Tabs.vue
@@ -11,9 +11,8 @@
           <ion-icon :icon="infiniteOutline" />
           <ion-label>{{ translate("Orders") }}</ion-label>
         </ion-tab-button>
-
         <ion-tab-button tab="more" href="/tabs/settings">
-          <ion-icon :icon="settings" />
+          <ion-icon :icon="settingsOutline" />
           <ion-label>{{ translate("Settings") }}</ion-label>
         </ion-tab-button>
       </ion-tab-bar>
@@ -25,7 +24,7 @@
 import { IonIcon, IonLabel, IonPage, IonTabBar, IonTabButton, IonTabs, IonRouterOutlet } from "@ionic/vue";
 import {
   infiniteOutline,
-  settings,
+  settingsOutline,
   shirtOutline,
 } from "ionicons/icons";
 import { translate } from "@hotwax/dxp-components";
@@ -36,7 +35,7 @@ export default {
   setup () {
     return {
       infiniteOutline,
-      settings,
+      settingsOutline,
       shirtOutline,
       translate
     };


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Replaced settings icon with settingsOutline icon for consistency

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before:

![image](https://github.com/user-attachments/assets/35918a35-6432-43ca-b763-207623d60820)

After:

![image](https://github.com/user-attachments/assets/d50db19b-c62f-4695-9cba-470d1d1820a3)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
