### PR TITLE
Improved: Displayed parent product name on product find page instead of the primary and secondary identifier.(#469)

### DIFF
--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -12,8 +12,7 @@
           <DxpShopifyImg :src="product.mainImageUrl" size="large"/>
           <ion-item lines="none">
             <ion-label>
-              <h2>{{ getProductIdentificationValue(productIdentificationPref.primaryId, product) }}</h2>
-              <p>{{ getProductIdentificationValue(productIdentificationPref.secondaryId, product) }}</p>
+              <h2>{{ product.productName }}</h2>
             </ion-label>
           </ion-item>
         </ion-card>


### PR DESCRIPTION
### Related Issues
#469 

### Short Description and Why It's Useful
Displayed parent product name on product find page instead of the primary and secondary identifier.


### Screenshots of Visual Changes before/after (If There Are Any)
![image](https://github.com/user-attachments/assets/ca14ca66-e50e-4760-b6e5-4e7e96a35c25)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
