### PR TITLE
Implemented: Added support for the edit picker on the details page of Open and Packed orders (#493)

### DIFF
--- a/src/components/EditPickerModal.vue
+++ b/src/components/EditPickerModal.vue
@@ -22,7 +22,7 @@
       <div class="empty-state" v-else-if="!availablePickers.length">{{ translate('No picker found') }}</div>
 
       <div v-else>
-        <ion-radio-group :value="selectedPicker.id">
+        <ion-radio-group :value="selectedPicker?.id">
           <ion-item v-for="(picker, index) in availablePickers" :key="index" @click="updateSelectedPicker(picker.id)">
             <ion-radio :value="picker.id">
               <ion-label>
@@ -90,7 +90,7 @@ import { PicklistService } from "@/services/PicklistService";
 import logger from "@/logger";
 
 export default defineComponent({
-  name: "EditPickersModal",
+  name: "EditPickerModal",
   components: { 
     IonButton,
     IonButtons,
@@ -155,6 +155,7 @@ export default defineComponent({
         ).toString()
       ).then(async () => {
         await event.target.complete();
+        this.getAlreadyAssignedPicker();
       });
     },
     async searchPicker() {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#493 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a chip for the edit picker on the details page of Open and Packed orders.  
- On the Open details page, if a picker is already selected, the chip label will display the picker's name. Clicking on the chip allows editing the picker through the edit picker modal.  
- If no default picker is present, the picker can be assigned, and then it can be edited using the chip on both the Open and Packed details pages.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/7ac750c6-f700-499d-9301-a6bcc59fe246)
![image](https://github.com/user-attachments/assets/57bcd96c-ac7d-42db-a903-dd72227ee740)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
