### PR TITLE
Fixed: On updating the facility, the settings related to the facility are also being updated (#500)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -183,13 +183,18 @@ const actions: ActionTree<UserState, RootState> = {
     // clearing the orders state whenever changing the facility
     dispatch("order/clearOrders", null, {root: true})
     dispatch("product/clearProducts", null, {root: true})
+    const previousEComStore = await useUserStore().getCurrentEComStore as any
+    // fetching the eComStore for updated facility
     const eComStore = await UserService.getCurrentEComStore(token, facilityId);
     await useUserStore().setEComStorePreference(eComStore);
     commit(types.USER_CURRENT_ECOM_STORE_UPDATED, eComStore)
-    //fetching partial order rejection config for BOPIS orders aftering updating facility
-    await dispatch("getPartialOrderRejectionConfig");
-    await dispatch("fetchBopisProductStoreSettings");
-    await useProductIdentificationStore().getIdentificationPref(eComStore?.productStoreId)
+
+    if(previousEComStore.productStoreId !== eComStore.productStoreId) {
+      //fetching partial order rejection config for BOPIS orders aftering updating facility
+      await dispatch("getPartialOrderRejectionConfig");
+      await dispatch("fetchBopisProductStoreSettings");
+      await useProductIdentificationStore().getIdentificationPref(eComStore?.productStoreId)
+    }
   },
   /**
    * Set User Instance Url

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -186,6 +186,8 @@ const actions: ActionTree<UserState, RootState> = {
     const eComStore = await UserService.getCurrentEComStore(token, facilityId);
     await useUserStore().setEComStorePreference(eComStore);
     commit(types.USER_CURRENT_ECOM_STORE_UPDATED, eComStore)
+    //fetching partial order rejection config for BOPIS orders aftering updating facility
+    await dispatch("getPartialOrderRejectionConfig");
     await useProductIdentificationStore().getIdentificationPref(eComStore?.productStoreId)
   },
   /**

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -188,6 +188,7 @@ const actions: ActionTree<UserState, RootState> = {
     commit(types.USER_CURRENT_ECOM_STORE_UPDATED, eComStore)
     //fetching partial order rejection config for BOPIS orders aftering updating facility
     await dispatch("getPartialOrderRejectionConfig");
+    await dispatch("fetchBopisProductStoreSettings");
     await useProductIdentificationStore().getIdentificationPref(eComStore?.productStoreId)
   },
   /**

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -186,10 +186,10 @@ const actions: ActionTree<UserState, RootState> = {
     const previousEComStore = await useUserStore().getCurrentEComStore as any
     // fetching the eComStore for updated facility
     const eComStore = await UserService.getCurrentEComStore(token, facilityId);
-    await useUserStore().setEComStorePreference(eComStore);
-    commit(types.USER_CURRENT_ECOM_STORE_UPDATED, eComStore)
 
     if(previousEComStore.productStoreId !== eComStore.productStoreId) {
+      await useUserStore().setEComStorePreference(eComStore);
+      commit(types.USER_CURRENT_ECOM_STORE_UPDATED, eComStore)
       //fetching partial order rejection config for BOPIS orders aftering updating facility
       await dispatch("getPartialOrderRejectionConfig");
       await dispatch("fetchBopisProductStoreSettings");

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -289,11 +289,10 @@ export default defineComponent({
   },
   methods: {
     async updateFacility(facility: any) {
-      const previousStoreId = this.currentEComStore.productStoreId
+      const previousEComStoreId = this.currentEComStore.productStoreId
       await this.store.dispatch('user/setFacility', facility?.facilityId);
       await this.store.dispatch('user/fetchNotificationPreferences')
-      const currentStoreId = this.currentEComStore.productStoreId
-      if(Object.keys(this.rerouteFulfillmentConfigMapping).length > 0 && previousStoreId !== currentStoreId) {
+      if(Object.keys(this.rerouteFulfillmentConfigMapping).length > 0 && previousEComStoreId !== this.currentEComStore.productStoreId) {
         this.getAvailableShipmentMethods();
         this.getRerouteFulfillmentConfiguration();
       }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -291,6 +291,7 @@ export default defineComponent({
     async updateFacility(facility: any) {
       await this.store.dispatch('user/setFacility', facility?.facilityId);
       await this.store.dispatch('user/fetchNotificationPreferences')
+      this.getRerouteFulfillmentConfiguration();
     },
     async timeZoneUpdated(tzId: string) {
       await this.store.dispatch("user/setUserTimeZone", tzId)
@@ -423,9 +424,16 @@ export default defineComponent({
           resp.data.docs.map((config: any) => {
             this.rerouteFulfillmentConfig[rerouteFulfillmentConfigMappingFlipped[config.settingTypeEnumId]] = config;
           })
+        } else {
+          Object.keys(this.rerouteFulfillmentConfigMapping).map((key) => {
+            this.rerouteFulfillmentConfig[key] = {};
+          });
         }
       } catch(err) {
         logger.error(err)
+        Object.keys(this.rerouteFulfillmentConfigMapping).map((key) => {
+          this.rerouteFulfillmentConfig[key] = {};
+        });
       }
     },
     async updateRerouteFulfillmentConfiguration(config: any, value: any) {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -291,7 +291,10 @@ export default defineComponent({
     async updateFacility(facility: any) {
       await this.store.dispatch('user/setFacility', facility?.facilityId);
       await this.store.dispatch('user/fetchNotificationPreferences')
-      this.getRerouteFulfillmentConfiguration();
+      if(Object.keys(this.rerouteFulfillmentConfigMapping).length > 0) {
+        this.getAvailableShipmentMethods();
+        this.getRerouteFulfillmentConfiguration();
+      }
     },
     async timeZoneUpdated(tzId: string) {
       await this.store.dispatch("user/setUserTimeZone", tzId)

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -289,9 +289,11 @@ export default defineComponent({
   },
   methods: {
     async updateFacility(facility: any) {
+      const previousStoreId = this.currentEComStore.productStoreId
       await this.store.dispatch('user/setFacility', facility?.facilityId);
       await this.store.dispatch('user/fetchNotificationPreferences')
-      if(Object.keys(this.rerouteFulfillmentConfigMapping).length > 0) {
+      const currentStoreId = this.currentEComStore.productStoreId
+      if(Object.keys(this.rerouteFulfillmentConfigMapping).length > 0 && previousStoreId !== currentStoreId) {
         this.getAvailableShipmentMethods();
         this.getRerouteFulfillmentConfiguration();
       }


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#500 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added the call to update the reroute fulfillment configuration when updating the facility and also handled the case when it has no configuration or when the API fails.
- Added the action call for updating the partial order rejection configuration on facility change.
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
