### PR TITLE
Improved: code to not fetch the unlinked product stores for facility and only fetch unique product stores

### DIFF
--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -48,6 +48,8 @@ const getCurrentEComStore = async (token: any, facilityId: any): Promise<any> =>
       "fieldList": ["defaultCurrencyUomId", "productStoreId"],
       "entityName": "ProductStoreFacilityDetail",
       "noConditionFind": "Y",
+      "distinct": "Y",
+      "filterByDate": "Y"
     }
     
     const resp = await client({


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When fetching product stores for facility we are also fetching those stores which are already unlinked from the facility, resulting in wrong store preference data being fetched, so added check to filter the records by date, also added check to only fetch unique records.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
