### PR TITLE
Improved: Added support to check order type for gift card(#516)

### DIFF
--- a/src/components/ProductListItem.vue
+++ b/src/components/ProductListItem.vue
@@ -21,7 +21,7 @@
         <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
       </ion-button>
 
-      <ion-button color="medium" fill="clear" size="small" v-if="item.productTypeId === 'GIFT_CARD'" @click.stop="openGiftCardActivationModal(item)">
+      <ion-button color="medium" fill="clear" size="small" v-if="orderType === 'packed' && item.productTypeId === 'GIFT_CARD'" @click.stop="openGiftCardActivationModal(item)">
         <ion-icon slot="icon-only" :icon="item.isGCActivated ? gift : giftOutline"/>
       </ion-button>
       
@@ -87,7 +87,7 @@ export default defineComponent({
       showKitComponents: false
     }
   },
-  props: ['item', 'isShipToStoreOrder', 'orderId'],
+  props: ['item', 'isShipToStoreOrder', 'orderId', 'orderType'],
   computed: {
     ...mapGetters({
       getProduct: 'product/getProduct',

--- a/src/views/OrderDetailUpdated.vue
+++ b/src/views/OrderDetailUpdated.vue
@@ -121,7 +121,7 @@
                     <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
                   </ion-button>
 
-                  <ion-button :disabled="order.handovered || order.shipped || order.cancelled || hasCancelledItems" v-if="getProduct(item.productId).productTypeId === 'GIFT_CARD'" color="medium" fill="clear" size="small" @click.stop="openGiftCardActivationModal(item)">
+                  <ion-button :disabled="order.handovered || order.shipped || order.cancelled || hasCancelledItems" v-if="orderType === 'packed' && getProduct(item.productId).productTypeId === 'GIFT_CARD'" color="medium" fill="clear" size="small" @click.stop="openGiftCardActivationModal(item)">
                     <ion-icon slot="icon-only" :icon="item.isGCActivated ? gift : giftOutline"/>
                   </ion-button>
 

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -98,7 +98,7 @@
               </ion-label>
             </ion-item>
 
-            <ProductListItem v-for="item in order.part.items" :key="item.productId" :item="item" :orderId="order.orderId"/>
+            <ProductListItem v-for="item in order.part.items" :key="item.productId" :item="item" :orderId="order.orderId" orderType="packed"/>
 
             <ion-item v-if="order.customer.phoneNumber">
               <ion-icon :icon="callOutline" slot="start" />


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#516 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Improved the `productListItem` by adding a check for the order status and ensuring that the gift card is displayed only for packed order types in the details view (#516).

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
