### PR TITLE
Improved: Set the viewSize to 250 when fetching gift card activation info for an order (#516)

### DIFF
--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -405,7 +405,7 @@ const fetchGiftCardActivationDetails = async ({ isDetailsPage, currentOrders }: 
         orderId_op: "in"
       },
       fieldList: ["amount", "cardNumber", "fulfillmentDate", "orderId", "orderItemSeqId"],
-      viewSize: orderIds.length
+      viewSize: 250
     })
 
     if(!hasError(resp)) {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#516

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Set the viewSize to 250 when fetching gift card activation info for an order

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
