### PR TITLE
The last item in the cancellation summary modal in packed order details page now has full lines. (#521)

### DIFF
--- a/src/components/ConfirmCancelModal.vue
+++ b/src/components/ConfirmCancelModal.vue
@@ -12,7 +12,7 @@
   <ion-content>
     <ion-list>
       <ion-list-header>{{ translate("Summary") }}</ion-list-header>
-      <ion-item v-for="(item, index) in cancelledItems" :key="index">
+      <ion-item v-for="(item, index) in cancelledItems" :key="index"  :lines="index === cancelledItems.length - 1 ? 'full' : 'inset'">
         <ion-thumbnail slot="start">
           <DxpShopifyImg :src="getProduct(item.productId).mainImageUrl" size="small" />
         </ion-thumbnail>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#521 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2025-03-26 16-48-08](https://github.com/user-attachments/assets/340fc6cf-971a-4941-a6ef-1762e27ff90f)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
