### PR TITLE
Improved: added gift card related checks for completed tab (#530)

### DIFF
--- a/src/components/ProductListItem.vue
+++ b/src/components/ProductListItem.vue
@@ -124,7 +124,7 @@ export default defineComponent({
       })
       modal.onDidDismiss().then((result: any) => {
         if(result.data?.isGCActivated) {
-          this.store.dispatch("order/updateCurrentItemGCActivationDetails", { item, orderId: this.orderId, isDetailsPage: false })
+          this.store.dispatch("order/updateCurrentItemGCActivationDetails", { item, orderId: this.orderId, orderType: this.orderType, isDetailsPage: false })
         }
       })
       modal.present();

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -396,7 +396,7 @@ const actions: ActionTree<OrderState , RootState> ={
       logger.error(err)
     }
 
-    if(orderDetails.orderType !== 'open') {
+    if(orderDetails.orderType !== "open") {
       order = await OrderService.fetchGiftCardActivationDetails({ isDetailsPage: true, currentOrders: [order] });
     }
 

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -1462,7 +1462,7 @@ const actions: ActionTree<OrderState , RootState> ={
     commit(types.ORDER_CURRENT_UPDATED, {order})
     return shipGroups;
   },
-  async updateCurrentItemGCActivationDetails({ commit, state }, { item, orderId, isDetailsPage }) {
+  async updateCurrentItemGCActivationDetails({ commit, state }, { item, orderId, orderType, isDetailsPage }) {
     let gcInfo = {};
     let isGCActivated = false;
 
@@ -1501,7 +1501,7 @@ const actions: ActionTree<OrderState , RootState> ={
       return;
     }
 
-    const orders = JSON.parse(JSON.stringify(state.packed.list));
+    const orders = orderType === "packed" ? JSON.parse(JSON.stringify(state.packed.list)) : JSON.parse(JSON.stringify(state.completed.list));
     orders.map((order: any) => {
       if(order.orderId === orderId) {
         order.parts.map((part: any) => {
@@ -1514,7 +1514,7 @@ const actions: ActionTree<OrderState , RootState> ={
         })
       }
     })
-    commit(types.ORDER_PACKED_UPDATED, { orders: orders, total: state.packed.total })
+    orderType === "packed" ? commit(types.ORDER_PACKED_UPDATED, { orders: orders, total: state.packed.total }) : commit(types.ORDER_COMPLETED_UPDATED, { orders: orders, total: state.completed.total })
   }
 }
 

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -396,7 +396,7 @@ const actions: ActionTree<OrderState , RootState> ={
       logger.error(err)
     }
 
-    if(orderDetails.orderType === 'packed') {
+    if(orderDetails.orderType !== 'open') {
       order = await OrderService.fetchGiftCardActivationDetails({ isDetailsPage: true, currentOrders: [order] });
     }
 
@@ -720,8 +720,9 @@ const actions: ActionTree<OrderState , RootState> ={
         })
 
         const total = resp.data.grouped?.orderId?.ngroups;
-
-        if(payload.viewIndex && payload.viewIndex > 0) orders = state.completed.list.concat(orders)
+        
+        const completedOrders = await OrderService.fetchGiftCardActivationDetails({ isDetailsPage: false, currentOrders: orders })
+        orders = payload.viewIndex && payload.viewIndex > 0 ? state.completed.list.concat(completedOrders) : completedOrders
         commit(types.ORDER_COMPLETED_UPDATED, { orders, total })
         if (payload.viewIndex === 0) emitter.emit("dismissLoader");
       } else {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#530 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Updated the check for fetching activation card information on the "Completed" tab.  
- Also, in case of pagination, maintained the consistency of the completed orders list after fetching the order list.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
