### PR TITLE
Implemented:Reprint packing slip from Completed tab "#558"

### DIFF
--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -155,6 +155,13 @@
                 {{ translate("Copy") }}
               </ion-button>
             </ion-item>
+             <div class="border-top">
+              <div></div>
+              <div></div>
+                <ion-button v-if="getBopisProductStoreSettings('PRINT_PACKING_SLIPS')" fill="clear" slot="end" @click.stop="rePrintPackingSlip(order)">
+                  <ion-icon slot="icon-only" :icon="printOutline"/> 
+                </ion-button>
+             </div>
           </ion-card>
         </div>
       </div>
@@ -216,6 +223,7 @@ import { OrderService } from "@/services/OrderService";
 import { UserService } from "@/services/UserService";
 import { Actions, hasPermission } from '@/authorization'
 import logger from "@/logger";
+import { UtilService } from "@/services/UtilService";
 
 export default defineComponent({
   name: 'Orders',
@@ -285,6 +293,39 @@ export default defineComponent({
     timeFromNow (time: any) {
       const timeDiff = DateTime.fromISO(time).diff(DateTime.local());
       return DateTime.local().plus(timeDiff).toRelative();
+    },
+    async rePrintPackingSlip(order: any) {
+      const completeOrderId = order?.orderId
+      const shipGroupSeqId = order?.shipGroupSeqId
+      const completeOrderShipId = await UtilService.fetchShipmentIdForOrder(shipGroupSeqId,completeOrderId)
+
+      if(completeOrderShipId){
+        try {
+            // Get packing slip from the server
+            const response: any = await api({
+              method: 'get',
+              url: 'PackingSlip.pdf',
+              params: {
+                shipmentId: completeOrderShipId
+              },
+              responseType: "blob"
+            })
+
+            if (!response || response.status !== 200 || hasError(response)) {
+              showToast(translate("Failed to load packing slip"))
+              return;
+            }
+
+            // Generate local file URL for the blob received
+            const pdfUrl = window.URL.createObjectURL(response.data);
+            // Open the file in new tab
+            (window as any).open(pdfUrl, "_blank").focus();
+
+          } catch(err) {
+            showToast(translate("Failed to load packing slip"))
+            logger.error(err)
+          }
+      }
     },
     async printPackingSlip(order: any) {
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#558 : Reprint packing slip from Completed tab.


### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Added an option to print the packing slip in the Completed order tab.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
<img width="1420" height="740" alt="Screenshot from 2025-07-18 16-00-53" src="https://github.com/user-attachments/assets/2dd2fac8-72ed-4523-9f76-1137ea6c4acc" />
<img width="1420" height="740" alt="Screenshot from 2025-07-18 16-01-20" src="https://github.com/user-attachments/assets/83bc9fde-c950-487b-971d-a13e38bbaa0f" />


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
