### PR TITLE
Fixed: pagination when setting total count of shipments being returned(#572)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -568,7 +568,7 @@ const actions: ActionTree<OrderState , RootState> ={
 
         await this.dispatch('product/fetchProducts', { productIds });
 
-        const total = shipments.length;
+        const total = resp.data.shipmentCount;
         const packedOrders = await OrderService.fetchGiftCardActivationDetails({
           isDetailsPage: false,
           currentOrders: orders


### PR DESCRIPTION
…(#572)

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
- Fixed pagination by setting the total shipments count.
- Used the `shipGroups` list to fetch `shipmentMethodTypeId`.

### Screenshots of Visual Changes before/after (If There Are Any)

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
