### PR TITLE
Improved: oms-api package version for fixing the auth headers issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@hotwax/app-version-info": "^1.0.0",
         "@hotwax/apps-theme": "^1.2.6",
         "@hotwax/dxp-components": "^1.22.1",
-        "@hotwax/oms-api": "^1.22.0",
+        "@hotwax/oms-api": "^1.23.0",
         "@ionic/core": "^7.6.0",
         "@ionic/vue": "^7.6.0",
         "@ionic/vue-router": "^7.6.0",
@@ -2884,9 +2884,9 @@
       }
     },
     "node_modules/@hotwax/oms-api": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@hotwax/oms-api/-/oms-api-1.22.0.tgz",
-      "integrity": "sha512-GwR/T+rdwNLtc7+PizEHIKluHH5VAzZ+dmKbto6hPNXcd51lSJqlUQJVAy6lvwZvIKcMLUusHPCC8NSCMofMdA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@hotwax/oms-api/-/oms-api-1.23.0.tgz",
+      "integrity": "sha512-8i6pqJVKFViIkqSGYfUhZY+4wSIj1jrbR7FKf+Fu88cixXK/noYH1QR8YGIgjMani7/3/syDtGwxByWf6AjIwA==",
       "dependencies": {
         "@types/node-json-transform": "^1.0.0",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@hotwax/app-version-info": "^1.0.0",
     "@hotwax/apps-theme": "^1.2.6",
     "@hotwax/dxp-components": "^1.22.1",
-    "@hotwax/oms-api": "^1.22.0",
+    "@hotwax/oms-api": "^1.23.0",
     "@ionic/core": "^7.6.0",
     "@ionic/vue": "^7.6.0",
     "@ionic/vue-router": "^7.6.0",


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
As we have removed code for fetching api_key for moqui first app, so need to use the updated oms-api package to not add api_key in headers and just use the JWT auth code for authorization.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
