### PR TITLE
Fixed: Pagination issue on the open orders tab(#568)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -157,7 +157,7 @@ const actions: ActionTree<OrderState , RootState> ={
 
         const total = resp.data.ordersCount;
 
-        if (params.viewIndex && params.viewIndex > 0) {
+        if (params.pageIndex && params.pageIndex > 0) {
           orders = state.open.list.concat(orders);
         }
 


### PR DESCRIPTION
### Related Issues
#568

### Short Description and Why It's Useful
- Used `pageIndex` and `pageSize` parameters to allow pagination on the open orders page.

### Screenshots of Visual Changes before/after (If There Are Any)


### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
