### PR TITLE
Fixed: user preference not being honored due to missing userId param in the api payload

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -76,7 +76,7 @@ const actions: ActionTree<UserState, RootState> = {
       const facilities = await useUserStore().getUserFacilities(userProfile?.partyId, "OMS_FULFILLMENT", isAdminUser)
       if(!facilities.length) throw "Unable to login. User is not associated with any facility"
 
-      await useUserStore().getFacilityPreference('SELECTED_FACILITY')
+      await useUserStore().getFacilityPreference('SELECTED_FACILITY', userProfile.userId)
     
       userProfile.facilities = facilities;
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
As we are using moqui endpoint for fetching user preference, it requires userId as input to correctly return the preference, thus updated the function params to include userId when fetching the preferences.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
