### PR TITLE
Fixed: issue of wrong segment being selected when coming from the details page to list page after refresh(#454)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -499,7 +499,7 @@ const actions: ActionTree<OrderState , RootState> ={
         currentOrder = order;
       }
 
-      await dispatch('updateCurrent', { order: currentOrder });
+      await dispatch('updateCurrent', { order: { ...currentOrder, orderType } });
 
     } else {
       throw resp.data;

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -131,6 +131,8 @@ export default defineComponent({
   },
 
   async ionViewWillEnter() {
+    // Clearing the current order as to correctly display the selected segment when moving to list page
+    this.store.dispatch("order/updateCurrent", { order: {}})
     this.isScrollingEnabled = false;
     this.queryString = this.products.queryString;
     this.getProducts();

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -228,6 +228,7 @@ export default defineComponent({
       unreadNotificationsStatus: 'user/getUnreadNotificationsStatus',
       getBopisProductStoreSettings: 'user/getBopisProductStoreSettings',
       getProductStock: 'stock/getProductStock',
+      order: "order/getCurrent"
     }),
     getOrdersByPart() {
       return Object.keys((this as any).orders).length ? (this as any).orders.flatMap((order: any) => order.shipGroups.map((shipGroup: any) => ({ ...order, shipGroup: { ...shipGroup, ...order.shipGroup } }))) : [];
@@ -569,6 +570,8 @@ export default defineComponent({
   ionViewWillEnter () {
     this.isScrollingEnabled = false;
     this.queryString = '';
+
+    this.segmentSelected = this.order?.orderType || "open"
 
     if(this.segmentSelected === 'open') {
       this.getPickupOrders()

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -273,6 +273,8 @@ export default defineComponent({
     this.appVersion = this.appInfo.branch ? (this.appInfo.branch + "-" + this.appInfo.revision) : this.appInfo.tag;
   },
   async ionViewWillEnter() {
+    // Clearing the current order as to correctly display the selected segment when moving to list page
+    this.store.dispatch("order/updateCurrent", { order: {}})
     // Only fetch configuration when environment mapping exists
     if (Object.keys(this.rerouteFulfillmentConfigMapping).length > 0) {
       this.fetchCarriers()


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#454 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added check to get the order type from state and set the same as selected segment so user lands on the segment in which the order belongs.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
