### PR TITLE
Improved: flow to use the local timezone switcher component and removed usage of Dxp component and fix wrong rejection history after page refresh

### DIFF
--- a/src/components/TimeZoneSwitcher.vue
+++ b/src/components/TimeZoneSwitcher.vue
@@ -42,7 +42,7 @@
 
     <ion-content>
       <div>
-        <ion-radio-group value="rd" v-model="timeZoneId">
+        <ion-radio-group v-model="timeZoneId">
           <ion-list v-if="showBrowserTimeZone">
             <ion-list-header>{{ translate("Browser time zone") }}</ion-list-header>
             <ion-item>
@@ -82,7 +82,7 @@
       </div>
 
       <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-        <ion-fab-button :disabled="!currentTimeZoneId" @click="setUserTimeZone">
+        <ion-fab-button :disabled="!timeZoneId || timeZoneId === currentTimeZoneId" @click="setUserTimeZone">
           <ion-icon :icon="saveOutline" />
         </ion-fab-button>
       </ion-fab>

--- a/src/components/TimeZoneSwitcher.vue
+++ b/src/components/TimeZoneSwitcher.vue
@@ -1,0 +1,215 @@
+<template>
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>
+        {{ translate('Timezone') }}
+      </ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      {{ translate('The timezone you select is used to ensure automations you schedule are always accurate to the time you select.') }}
+    </ion-card-content>
+    <ion-item v-if="showBrowserTimeZone">
+      <ion-label>
+        <p class="overline">{{ translate("Browser TimeZone") }}</p>
+        {{ browserTimeZone.id }}
+        <p v-if="showDateTime">{{ getCurrentTime(browserTimeZone.id, dateTimeFormat) }}</p>
+      </ion-label>
+    </ion-item>
+    <ion-item lines="none">
+      <ion-label>
+        <p class="overline">{{ translate("Selected TimeZone") }}</p>
+        {{ currentTimeZoneId }}
+        <p v-if="showDateTime">{{ getCurrentTime(currentTimeZoneId, dateTimeFormat) }}</p>
+      </ion-label>
+      <ion-button id="time-zone-modal" slot="end" fill="outline" color="dark">{{ translate("Change") }}</ion-button>
+    </ion-item>
+  </ion-card>
+  <!-- Using inline modal(as recommended by ionic), also using it inline as the component inside modal is not getting mounted when using modalController -->
+  <ion-modal ref="timeZoneModal" trigger="time-zone-modal" @didPresent="search()" @didDismiss="clearSearch()">
+    <ion-header>
+      <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-button @click="closeModal">
+            <ion-icon :icon="closeOutline" />
+          </ion-button>
+        </ion-buttons>
+        <ion-title>{{ translate("Select time zone") }}</ion-title>
+      </ion-toolbar>
+      <ion-toolbar>
+        <ion-searchbar @ionFocus="selectSearchBarText($event)" :placeholder="translate('Search time zones')"  v-model="queryString" @keyup.enter="queryString = $event.target.value; findTimeZone()" @keydown="preventSpecialCharacters($event)" />
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content>
+      <div>
+        <ion-radio-group value="rd" v-model="timeZoneId">
+          <ion-list v-if="showBrowserTimeZone">
+            <ion-list-header>{{ translate("Browser time zone") }}</ion-list-header>
+            <ion-item>
+              <ion-radio label-placement="end" justify="start" :value="browserTimeZone.id">
+                <ion-label>
+                  {{ browserTimeZone.label }} ({{ browserTimeZone.id }})
+                  <p v-if="showDateTime">{{ getCurrentTime(browserTimeZone.id, dateTimeFormat) }}</p>
+                </ion-label>
+              </ion-radio>
+            </ion-item>
+          </ion-list>
+          <ion-list>
+            <ion-list-header v-if="showBrowserTimeZone">{{ translate("Select a different time zone") }}</ion-list-header>
+            <!-- Loading state -->
+            <div class="empty-state" v-if="isLoading">
+              <ion-item lines="none">
+                <ion-spinner color="secondary" name="crescent" slot="start" />
+                {{ translate("Fetching time zones") }}
+              </ion-item>
+            </div>
+            <!-- Empty state -->
+            <div class="empty-state" v-else-if="filteredTimeZones.length === 0">
+              <p>{{ translate("No time zone found") }}</p>
+            </div>
+            <div v-else>
+              <ion-item :key="timeZone.id" v-for="timeZone in filteredTimeZones">
+                <ion-radio label-placement="end" justify="start" :value="timeZone.id">
+                  <ion-label>
+                    {{ timeZone.label }} ({{ timeZone.id }})
+                    <p v-if="showDateTime">{{ getCurrentTime(timeZone.id, dateTimeFormat) }}</p>
+                  </ion-label>
+                </ion-radio>
+              </ion-item>
+            </div>
+          </ion-list>
+        </ion-radio-group>
+      </div>
+
+      <ion-fab vertical="bottom" horizontal="end" slot="fixed">
+        <ion-fab-button :disabled="!currentTimeZoneId" @click="setUserTimeZone">
+          <ion-icon :icon="saveOutline" />
+        </ion-fab-button>
+      </ion-fab>
+    </ion-content>
+  </ion-modal>
+</template>
+
+<script setup lang="ts">
+import {
+  IonButton,
+  IonButtons,
+  IonCard, 
+  IonCardHeader,
+  IonCardTitle,
+  IonCardContent,
+  IonContent,
+  IonFab,
+  IonFabButton,
+  IonHeader,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonListHeader,
+  IonModal,
+  IonRadio,
+  IonRadioGroup,
+  IonSearchbar,
+  IonSpinner,
+  IonTitle,
+  IonToolbar
+} from '@ionic/vue';
+import { closeOutline, saveOutline } from "ionicons/icons";
+import { computed, onBeforeMount, ref, defineProps, defineEmits } from "vue";
+import { getCurrentTime } from '../utils'
+import { translate, useUserStore } from "@hotwax/dxp-components"
+import store from '@/store';
+
+const userStore = useUserStore();
+
+const userProfile = computed(() => store.getters["user/getUserProfile"])
+const timeZones = computed(() => userStore.getTimeZones)
+const currentTimeZoneId = computed(() => userProfile.value.timeZone)
+
+const isLoading = ref(true);
+const timeZoneModal = ref();
+const queryString = ref('');
+const filteredTimeZones = ref([])
+const timeZoneId = ref('')
+// Fetching timeZone of the browser
+const browserTimeZone = ref({
+  label: '',
+  id: Intl.DateTimeFormat().resolvedOptions().timeZone
+})
+
+const emit = defineEmits(["timeZoneUpdated"])
+
+const props = defineProps({
+  showBrowserTimeZone: {
+    type: Boolean,
+    default: true
+  },
+  showDateTime: {
+    type: Boolean,
+    default: true
+  },
+  dateTimeFormat: {
+    type: String,
+    default: 't ZZZZ'
+  }
+})
+
+const closeModal = () => {
+  timeZoneModal.value.$el.dismiss(null, 'cancel');
+}
+
+onBeforeMount(async () => {
+  isLoading.value = true;
+  await userStore.getAvailableTimeZones();
+
+  if(userProfile.value && userProfile.value.timeZone) {
+    userStore.currentTimeZoneId = userProfile.value.timeZone
+    timeZoneId.value = userProfile.value.timeZone
+  }
+
+  if(props.showBrowserTimeZone) {
+    browserTimeZone.value.label = timeZones.value.find((timeZone: any) => timeZone.id.toLowerCase().match(browserTimeZone.value.id.toLowerCase()))?.label
+  }
+
+  findTimeZone();
+  isLoading.value = false;
+})
+
+async function setUserTimeZone() {
+  emit('timeZoneUpdated', timeZoneId.value);
+  closeModal();
+}
+
+function findTimeZone() {
+  const searchedString = queryString.value.toLowerCase();
+  filteredTimeZones.value = timeZones.value.filter((timeZone: any) => timeZone.id.toLowerCase().match(searchedString) || timeZone.label.toLowerCase().match(searchedString));
+
+  if(props.showBrowserTimeZone) {
+    filteredTimeZones.value = filteredTimeZones.value.filter((timeZone: any) => !timeZone.id.toLowerCase().match(browserTimeZone.value.id.toLowerCase()));
+  }
+}
+
+async function selectSearchBarText(event: any) {
+  const element = await event.target.getInputElement()
+  element.select();
+}
+
+function preventSpecialCharacters($event: any) {
+  // Searching special characters fails the API, hence, they must be omitted
+  if(/[`!@#$%^&*()_+\-=\\|,.<>?~]/.test($event.key)) $event.preventDefault();
+}
+
+function search() {
+  isLoading.value = true;
+  findTimeZone();
+  isLoading.value = false;
+}
+
+// clearing the data explicitely as the modal is mounted due to the component being mounted always
+function clearSearch() {
+  queryString.value = ''
+  filteredTimeZones.value = []
+  isLoading.value = true
+}
+</script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ import { dxpComponents } from '@hotwax/dxp-components'
 import localeMessages from './locales';
 import { login, logout, loader } from '@/utils/user';
 import { addNotification, storeClientRegistrationToken } from '@/utils/firebase';
-import { getConfig, fetchGoodIdentificationTypes, getProductIdentificationPref, getUserFacilities, getUserPreference, initialise, setProductIdentificationPref, setUserLocale, getAvailableTimeZones, setUserTimeZone, setUserPreference } from '@/adapter';
+import { getConfig, fetchGoodIdentificationTypes, getProductIdentificationPref, getUserFacilities, getUserPreference, initialise, setProductIdentificationPref, setUserLocale, getAvailableTimeZones, setUserPreference } from '@/adapter';
 import logger from './logger';
 
 const app = createApp(App)
@@ -73,7 +73,6 @@ const app = createApp(App)
     storeClientRegistrationToken,
     getAvailableTimeZones,
     hasPermission,
-    setUserTimeZone,
     getUserFacilities,
     setUserPreference,
     getUserPreference
@@ -91,7 +90,7 @@ app.config.globalProperties.$filters = {
     // TODO Make default format configurable and from environment variables
     const userProfile = store.getters['user/getUserProfile'];
     // TODO Fix this setDefault should set the default timezone instead of getting it everytiem and setting the tz
-    return DateTime.fromISO(value, { zone: 'utc' }).setZone(userProfile.userTimeZone).toFormat(outFormat ? outFormat : 'MM-dd-yyyy')  
+    return DateTime.fromISO(value, { zone: 'utc' }).setZone(userProfile.timeZone).toFormat(outFormat ? outFormat : 'MM-dd-yyyy')  
   },
   getIdentificationId(identifications: any, id: string) {
     let  externalId = ''

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,4 +1,4 @@
-import { apiClient, client, hasError } from '@/adapter';
+import { api, apiClient, client, hasError } from '@/adapter';
 
 import store from '@/store';
 
@@ -37,6 +37,23 @@ const getUserProfile = async (token: any): Promise<any> => {
     return Promise.resolve(resp.data)
   } catch(error: any) {
     return Promise.reject(error)
+  }
+}
+
+async function setUserTimeZone(payload: any): Promise<any> {
+  try {
+    const resp = await api({
+      url: "admin/user/profile",
+      method: "POST",
+      data: payload,
+    }) as any;
+    return Promise.resolve(resp.data);
+  } catch (error: any) {
+    return Promise.reject({
+      code: "error",
+      message: "Failed to set user time zone",
+      serverResponse: error
+    });
   }
 }
 
@@ -299,5 +316,6 @@ export const UserService = {
     updateRerouteFulfillmentConfig,
     getPartialOrderRejectionConfig,
     createPartialOrderRejectionConfig,
-    updatePartialOrderRejectionConfig
+    updatePartialOrderRejectionConfig,
+    setUserTimeZone
 }

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -101,8 +101,8 @@ const actions: ActionTree<UserState, RootState> = {
       /*  ---- Guard clauses ends here --- */
 
       setPermissions(appPermissions);
-      if (userProfile.userTimeZone) {
-        Settings.defaultZone = userProfile.userTimeZone;
+      if (userProfile.timeZone) {
+        Settings.defaultZone = userProfile.timeZone;
       }
 
       // TODO user single mutation
@@ -227,9 +227,17 @@ const actions: ActionTree<UserState, RootState> = {
    */
   async setUserTimeZone ( { state, commit }, timeZoneId) {
     const current: any = state.current;
-    current.userTimeZone = timeZoneId;
-    commit(types.USER_INFO_UPDATED, current);
-    Settings.defaultZone = current.userTimeZone;
+    try {
+      await UserService.setUserTimeZone(({ userId: current.userId, timeZone: timeZoneId }));
+      current.timeZone = timeZoneId;
+      commit(types.USER_INFO_UPDATED, current);
+      Settings.defaultZone = current.timeZone;
+      showToast(translate("Time zone updated successfully"));
+    } catch(err) {
+      logger.error(err)
+      showToast(translate("Failed to update time zone"));
+    }
+
   },
 
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -118,8 +118,13 @@ const hasWebcamAccess = async () => {
   }
 }
 
+// TimeZone format = 04:16 PM EDT
+const getCurrentTime = (zone: string, format = 't ZZZZ') => {
+  return DateTime.now().setZone(zone).toFormat(format)
+}
+
 const getPickerName = (pickerGroupName: string, pickerFirstName: string, pickerLastName: string) => {
   return pickerGroupName ? pickerGroupName : pickerFirstName ? `${pickerFirstName} ${pickerLastName ? pickerLastName : ''}`.trim() : '';
 }
 
-export { copyToClipboard, showToast, handleDateTimeInput, hasWebcamAccess, getFeature, formatPhoneNumber, getCurrentFacilityId, getColorByDesc, formatCurrency, getPickerName }
+export { copyToClipboard, getCurrentTime, showToast, handleDateTimeInput, hasWebcamAccess, getFeature, formatPhoneNumber, getCurrentFacilityId, getColorByDesc, formatCurrency, getPickerName }

--- a/src/views/OrderDetailUpdated.vue
+++ b/src/views/OrderDetailUpdated.vue
@@ -1277,10 +1277,11 @@ export default defineComponent({
     emitter.emit("presentLoader")
     await this.getOrderDetail(this.orderId, this.shipGroupSeqId, this.orderType);
 
-    // fetch rejection reasons only when we get the orders information
-    if(this.order.orderId) {
-      this.orderType === "open" ? await this.fetchRejectReasons() : await this.fetchCancelReasons();
-    }
+    // Removed condition of order type and fetched both rejection and cancellation reasons
+    // as when fetching conditionally the rejection reasons are not fetched correctly resulting in wrong
+    // rejection history being displayed
+    await this.fetchRejectReasons()
+    await this.fetchCancelReasons()
 
     if(this.orderType === "packed") {
       this.fetchJobs();

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -120,7 +120,7 @@
 
       <section>
         <DxpProductIdentifier />
-        <DxpTimeZoneSwitcher @timeZoneUpdated="timeZoneUpdated" />
+        <TimeZoneSwitcher @timeZoneUpdated="timeZoneUpdated" />
         <DxpLanguageSwitcher />
 
         <ion-card>
@@ -226,12 +226,13 @@ import { DateTime } from 'luxon';
 import { UserService } from '@/services/UserService'
 import { showToast } from '@/utils';
 import { hasError, removeClientRegistrationToken, subscribeTopic, unsubscribeTopic } from '@/adapter'
-import { DxpTimeZoneSwitcher, goToOms, initialiseFirebaseApp, translate, useUserStore } from "@hotwax/dxp-components";
+import { goToOms, initialiseFirebaseApp, translate, useUserStore } from "@hotwax/dxp-components";
 import { Actions, hasPermission } from '@/authorization'
 import { addNotification, generateTopicName, isFcmConfigured, storeClientRegistrationToken } from "@/utils/firebase";
 import emitter from "@/event-bus"
 import logger from '@/logger';
 import EditShipmentMethodModal from '@/components/EditShipmentMethodModal.vue';
+import TimeZoneSwitcher from "@/components/TimeZoneSwitcher.vue"
 
 export default defineComponent({
   name: 'Settings',
@@ -253,7 +254,8 @@ export default defineComponent({
     IonTitle,
     IonToggle, 
     IonToolbar,
-    Image
+    Image,
+    TimeZoneSwitcher
   },
   data(){
     return {


### PR DESCRIPTION
Reverted the change made in 635, initally handled in 607
Reverted as we do not have full support of using dxp component in moqui first apps

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
