### PR TITLE
Fixed: flow to do not allow editing pickers when order is rejected and removed unawanted loader displaying when assign picker modal is closed without selecting any picker(#719)

### DIFF
--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -53,7 +53,7 @@
               <h1 data-testid="order-name-tag">{{ order.orderName }}</h1>
               <p data-testid="order-id-tag">{{ order.orderId }}</p>
             </ion-label>
-            <ion-chip data-testid="edit-picker-chip" :disabled="!hasPermission(Actions.APP_ORDER_UPDATE) || order.handovered || order.shipped || order.cancelled" v-if="order.pickers && (orderType === 'open' || orderType === 'packed') && getBopisProductStoreSettings('ENABLE_TRACKING')" outline slot="end" @click="editPicker(order)">
+            <ion-chip data-testid="edit-picker-chip" :disabled="!hasPermission(Actions.APP_ORDER_UPDATE) || order.handovered || order.shipped || order.rejected || order.cancelled" v-if="order.pickers && (orderType === 'open' || orderType === 'packed') && getBopisProductStoreSettings('ENABLE_TRACKING')" outline slot="end" @click="editPicker(order)">
               <ion-icon :icon="personOutline"/>
               <ion-label>{{ order.pickers }}</ion-label>
             </ion-chip>
@@ -489,13 +489,13 @@ export default defineComponent({
         componentProps: { order, shipGroup, facilityId }
       });
       assignPickerModal.onDidDismiss().then(async(result: any) => {
-        emitter.emit("presentLoader");
         if(result.data?.selectedPicker) {
+          emitter.emit("presentLoader");
           await this.createPicklist(order, result.data.selectedPicker);
           await this.store.dispatch('order/packShipGroupItems', { order, shipGroup })
           await this.getOrderDetail(this.orderId, this.shipGroupSeqId, this.orderType);
+          emitter.emit("dismissLoader");
         }
-        emitter.emit("dismissLoader");
       })
 
       return assignPickerModal.present();

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -250,14 +250,14 @@ export default defineComponent({
         componentProps: { order, shipGroup, facilityId }
       });
       assignPickerModal.onDidDismiss().then(async(result: any) => {
-        emitter.emit("presentLoader");
         if(result.data?.selectedPicker) {
+          emitter.emit("presentLoader");
           await this.createPicklist(order, result.data.selectedPicker);
-          const updatedOrder  = this.orders.find((ord: any) => ord.orderId === order.orderId);
+          const updatedOrder = this.orders.find((ord: any) => ord.orderId === order.orderId);
           const updatedShipGroup = updatedOrder.shipGroups.find((sg: any) => sg.shipGroupSeqId === shipGroup.shipGroupSeqId);
           await this.store.dispatch('order/packShipGroupItems', { order: updatedOrder, shipGroup: updatedShipGroup })
+          emitter.emit("dismissLoader");
         }
-        emitter.emit("dismissLoader");
       })
 
       return assignPickerModal.present();


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#719 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
