### PR TITLE
fix: triggered STS completion email only when all ship groups are handed over(#739)

### DIFF
--- a/src/views/ShipToStoreOrders.vue
+++ b/src/views/ShipToStoreOrders.vue
@@ -337,7 +337,7 @@ export default defineComponent({
             const incomingParams = {
               orderId,
               orderFacilityId: this.currentFacility?.facilityId,
-              pageSize: 1,
+              pageSize: 10,
               orderStatusId: 'ORDER_COMPLETED,ORDER_APPROVED',
               statusId: 'ITEM_COMPLETED,ITEM_APPROVED',
               shipmentMethodTypeId: 'SHIP_TO_STORE',
@@ -408,31 +408,20 @@ export default defineComponent({
           const checkShipGroupParams = {
             orderId,
             orderFacilityId: this.currentFacility?.facilityId,
-            pageSize: 1
+            pageSize: 10
           };
 
-          const incomingParams = {
+          const pendingShipGroupParams = {
             ...checkShipGroupParams,
             orderStatusId: 'ORDER_COMPLETED,ORDER_APPROVED',
             statusId: 'ITEM_COMPLETED,ITEM_APPROVED',
             shipmentMethodTypeId: 'SHIP_TO_STORE',
-            shipmentStatusId: 'SHIPMENT_INPUT,SHIPMENT_APPROVED,SHIPMENT_PACKED,SHIPMENT_SHIPPED',
+            shipmentStatusId: 'SHIPMENT_INPUT,SHIPMENT_APPROVED,SHIPMENT_PACKED,SHIPMENT_SHIPPED,SHIPMENT_ARRIVED',
           };
 
-          const readyForPickupParams = {
-            ...checkShipGroupParams,
-            shipmentStatusId: 'SHIPMENT_ARRIVED',
-            shipmentMethodTypeId: 'SHIP_TO_STORE',
-            statusId: 'ITEM_COMPLETED',
-            orderStatusId: 'ORDER_COMPLETED',
-          };
+          const resp = await OrderService.getShipToStoreOrders(pendingShipGroupParams);
 
-          const [incomingResp, readyForPickupResp] = await Promise.all([
-            OrderService.getShipToStoreOrders(incomingParams),
-            OrderService.getShipToStoreOrders(readyForPickupParams)
-          ]);
-
-          const isLastShipGroup = !hasError(incomingResp) && !hasError(readyForPickupResp) && incomingResp.data.ordersCount === 0 && readyForPickupResp.data.ordersCount === 0;
+          const isLastShipGroup = !hasError(resp) && resp.data.ordersCount === 0;
 
           if (isLastShipGroup) {
             try {
@@ -450,7 +439,6 @@ export default defineComponent({
           } else {
             showToast(translate('Order handed over successfully'));
           }
-
           // Refresh the lists for UI update.
           this.getReadyForPickupOrders();
         } else {


### PR DESCRIPTION
### Related Issues
<!-- Put related issue number which this PR is closing. For example #123 -->
#739 

### Short Description and Why It's Useful
Refactored Ship-to-Store (STS) notification logic to use direct backend queries instead of Vuex state. This ensures that "Ready for Pickup" and "Order Completed" emails are only sent when all parts of an order are actually processed, bypassing issues with pagination and stale state.

**Key Changes:**
- **Exact Order Checking:** Uses direct API calls with `orderId` filtering to accurately count remaining ship groups.
- **Improved Email Triggers:** Notifications are now sent only when the backend confirms zero items remain in the relevant status.
- **Reliable Split Orders:** Prevents premature completion emails for orders split across shipments or facilities.
- **Clearer Feedback:** Updated toast messages to distinguish between partial ship group updates and full order completion.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
- No visual UI changes. Impact is on background logic and toast message text.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed contribution rules