### PR TITLE
Improvement: 764 order contact info update

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -283,7 +283,7 @@ const actions: ActionTree<OrderState , RootState> ={
       order.address = hasObjectValue(order.billingAddress) ? order.billingAddress :
                       hasObjectValue(order.shippingAddress) ? order.shippingAddress : null;
 
-      order.email = order.billingEmail || order.orderEmail || null;
+      order.email = order.billingEmail || order.orderEmail || order.shippingEmail || null;
 
       order.phone = hasObjectValue(order.billingPhone) ? order.billingPhone :
                     hasObjectValue(order.shippingPhone) ? order.shippingPhone : null;


### PR DESCRIPTION

Changelog: Fixed

Included shippingEmail in order email assignment.
Small improvement over branch: 764-order-contact-info-update

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
- #764

### Related PRs
<!--  Put related issue number which this PR is closing. For example #123 -->
- https://github.com/hotwax/bopis/pull/767

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Previously, the OMS `get#SalesOrder` API rigidly restricted contact details to billing-specific elements (`BILLING_LOCATION`, `BILLING_EMAIL`, `PHONE_BILLING`), causing missing contact information in the Store Pickup (BOPIS) app if an order lacked billing data. The [bopis#767](https://github.com/hotwax/bopis/pull/767) was created to fix that.

This Pull Request resolves the data visibility issue by abstracting the contact mechanism logic:
**Frontend Standardization (`actions.ts`)**: The application now has another email data fallback - `shipping address` on the client side mapping to generic variable - `email`.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
