### PR TITLE
Enable IDE Trace Vue plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@typescript-eslint/parser": "~5.26.0",
     "@vitejs/plugin-legacy": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
-    "chrome-ide-trace": "^0.1.0",
+    "chrome-ide-trace": "^0.1.1",
     "@vue/compiler-sfc": "^3.5.22",
     "@vue/eslint-config-typescript": "^12.0.0",
     "@vue/test-utils": "^2.4.6",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@ionic/core": "catalog:",
     "@ionic/vue": "catalog:",
     "@ionic/vue-router": "catalog:",
+    "ionicons": "catalog:",
     "vue-router": "catalog:",
     "firebase": "catalog:",
     "luxon": "catalog:",
@@ -50,6 +51,7 @@
     "terser": "^5.30.0",
     "typescript": "catalog:",
     "vite": "catalog:",
+    "vite-plugin-pwa": "1.2.0",
     "vitest": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@typescript-eslint/parser": "~5.26.0",
     "@vitejs/plugin-legacy": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
+    "chrome-ide-trace": "^0.1.0",
     "@vue/compiler-sfc": "^3.5.22",
     "@vue/eslint-config-typescript": "^12.0.0",
     "@vue/test-utils": "^2.4.6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../accxui/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "types": [
@@ -11,10 +11,10 @@
         "src/*"
       ],
       "@common": [
-        "../../common/index.ts"
+        "../accxui/common/index.ts"
       ],
       "@common/*": [
-        "../../common/*"
+        "../accxui/common/*"
       ]
     },
     "lib": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import vue from '@vitejs/plugin-vue'
+import { ideTraceVue } from 'chrome-ide-trace/vite'
 import legacy from '@vitejs/plugin-legacy'
 import path from 'path'
 import { defineConfig } from 'vite'
@@ -10,6 +11,7 @@ import manifest from "./manifest.json"
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
+    ideTraceVue(),
     vue(),
     legacy(),
     VitePWA({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import legacy from '@vitejs/plugin-legacy'
 import path from 'path'
 import { defineConfig } from 'vite'
 import { versionInfoUtil } from '../../common/utils/versionInfoUtil'
+import { localMoquiDiscoveryPlugin } from '../../common/vite/localMoquiDiscoveryPlugin'
 import pkg from './package.json'
 import { VitePWA } from 'vite-plugin-pwa'
 import manifest from "./manifest.json"
@@ -19,7 +20,8 @@ export default defineConfig({
       devOptions: {
         enabled: true
       }
-    })
+    }),
+    localMoquiDiscoveryPlugin()
   ],
   define: {
     'import.meta.env.VITE_APP_VERSION_INFO': JSON.stringify(JSON.stringify(versionInfoUtil.getVersionInfo(pkg.version)))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,7 @@ import vue from '@vitejs/plugin-vue'
 import legacy from '@vitejs/plugin-legacy'
 import path from 'path'
 import { defineConfig } from 'vite'
-import { versionInfoUtil } from '../../common/utils/versionInfoUtil'
-import { localMoquiDiscoveryPlugin } from '../../common/vite/localMoquiDiscoveryPlugin'
+import { versionInfoUtil } from '../accxui/common/utils/versionInfoUtil'
 import pkg from './package.json'
 import { VitePWA } from 'vite-plugin-pwa'
 import manifest from "./manifest.json"
@@ -20,8 +19,7 @@ export default defineConfig({
       devOptions: {
         enabled: true
       }
-    }),
-    localMoquiDiscoveryPlugin()
+    })
   ],
   define: {
     'import.meta.env.VITE_APP_VERSION_INFO': JSON.stringify(JSON.stringify(versionInfoUtil.getVersionInfo(pkg.version)))
@@ -30,7 +28,7 @@ export default defineConfig({
     dedupe: ['vue', 'pinia'],
     alias: {
       '@': path.resolve(__dirname, 'src'),
-      '@common': path.resolve(__dirname, '../../common')
+      '@common': path.resolve(__dirname, '../accxui/common')
     },
   },
   server: {


### PR DESCRIPTION
## Summary\n\nAdds IDE Trace plugin wiring to this app's Vite config and package config for Chrome DevTools integration from IDE Trace browser extension.\n\n## Files\n- package.json: add chrome-ide-trace devDependency\n- vite.config.{ts,js}: add ideTraceVue import and plugin entry