### PR TITLE
Fix add missing facilityId guard clause to topic subscription

### DIFF
--- a/src/components/NotificationPreferenceModal.vue
+++ b/src/components/NotificationPreferenceModal.vue
@@ -138,6 +138,10 @@ export default defineComponent({
     },
     async handleTopicSubscription() {
       const facilityId = this.currentFacility?.facilityId
+       if (!facilityId) {
+    logger.error('Facility ID is missing, cannot subscribe to topics');
+    return;
+  }
       const subscribeRequests = this.notificationPrefToUpdate.subscribe.map((enumId: string) => {
         const topicName = generateTopicName(facilityId, enumId)
         return subscribeTopic(topicName, process.env.VUE_APP_NOTIF_APP_ID)

--- a/src/components/NotificationPreferenceModal.vue
+++ b/src/components/NotificationPreferenceModal.vue
@@ -138,10 +138,11 @@ export default defineComponent({
     },
     async handleTopicSubscription() {
       const facilityId = this.currentFacility?.facilityId
-       if (!facilityId) {
-    logger.error('Facility ID is missing, cannot subscribe to topics');
-    return;
-  }
+      if (!facilityId) {
+        logger.error('Facility ID is missing, cannot subscribe to topics');
+        showToast(translate('Notification preferences not updated. Please try again.'));
+        return;
+      }
       const subscribeRequests = this.notificationPrefToUpdate.subscribe.map((enumId: string) => {
         const topicName = generateTopicName(facilityId, enumId)
         return subscribeTopic(topicName, process.env.VUE_APP_NOTIF_APP_ID)


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#773

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Adds a guard clause to `handleTopicSubscription` in `NotificationPreferenceModal.vue` to check if `facilityId` is defined before attempting to generate a topic name and subscribe. 

This prevents the app from generating invalid topic strings (e.g. containing `"undefined"`) and sending incorrect subscription requests to Firebase/OMS when no facility is selected. This officially resolves the feedback provided by the `gemini-code-assist` bot on PR #773.


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
