### PR TITLE
fix: validate success flag in pickup notification responses

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -156,6 +156,7 @@
   "Order completed": "Order completed",
   "Order delivered to": "Order delivered to { customerName }",
   "Order details": "Order details",
+  "Order Details have been successfully saved, but failed to send email notification to the customer due to missing configuration.": "Order Details have been successfully saved, but failed to send email notification to the customer due to missing configuration.",
   "Order edit permissions": "Order edit permissions",
   "Order is now ready to handover.": "Order is now ready to handover.",
   "Order is now ready to be shipped.": "Order is now ready to be shipped.",

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -1041,7 +1041,7 @@ async function sendReadyForPickupEmail(orderRef: any) {
         handler: async () => {
           try {
             const resp = await useOrderStore().sendPickupScheduledNotification({ shipmentId: orderRef.shipmentId });
-            if (!commonUtil.hasError(resp) && resp.data?.success === "true") {
+            if (!commonUtil.hasError(resp) && resp.data?.success === true) {
               commonUtil.showToast(translate("Email sent successfully"))
             } else {
               commonUtil.showToast(translate("Something went wrong while sending the email."))

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -1041,7 +1041,7 @@ async function sendReadyForPickupEmail(orderRef: any) {
         handler: async () => {
           try {
             const resp = await useOrderStore().sendPickupScheduledNotification({ shipmentId: orderRef.shipmentId });
-            if (!commonUtil.hasError(resp)) {
+            if (!commonUtil.hasError(resp) && resp.data?.success === "true") {
               commonUtil.showToast(translate("Email sent successfully"))
             } else {
               commonUtil.showToast(translate("Something went wrong while sending the email."))

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -1041,7 +1041,7 @@ async function sendReadyForPickupEmail(orderRef: any) {
         handler: async () => {
           try {
             const resp = await useOrderStore().sendPickupScheduledNotification({ shipmentId: orderRef.shipmentId });
-            if (!commonUtil.hasError(resp) && resp.data?.success === true) {
+            if (!commonUtil.hasError(resp) && resp.data?.success) {
               commonUtil.showToast(translate("Email sent successfully"))
             } else {
               commonUtil.showToast(translate("Something went wrong while sending the email."))

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -412,7 +412,7 @@ async function sendReadyForPickupEmail(orderData: any) {
         handler: async () => {
           try {
             const resp = await orderStore.sendPickupScheduledNotification({ shipmentId: orderData.shipmentId });
-            if (!commonUtil.hasError(resp)) {
+            if (!commonUtil.hasError(resp) && resp.data?.success === "true") {
               commonUtil.showToast(translate("Email sent successfully"))
             } else {
               commonUtil.showToast(translate("Something went wrong while sending the email."))
@@ -604,7 +604,7 @@ async function openProofOfDeliveryModal(orderData: any, isViewModeOnly: any) {
       // Send the proof of delivery email
       const resp = await orderStore.sendPickupNotification(data.proofOfDeliveryData);
 
-      if (commonUtil.hasError(resp)) {
+      if (commonUtil.hasError(resp) || resp.data?.success === "false") {
         logger.error("Pickup notification failed:", resp);
         commonUtil.showToast(translate("Unable to save the details. Please try again."));
       } else {

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -412,7 +412,7 @@ async function sendReadyForPickupEmail(orderData: any) {
         handler: async () => {
           try {
             const resp = await orderStore.sendPickupScheduledNotification({ shipmentId: orderData.shipmentId });
-            if (!commonUtil.hasError(resp) && resp.data?.success === "true") {
+            if (!commonUtil.hasError(resp) && resp.data?.success === true) {
               commonUtil.showToast(translate("Email sent successfully"))
             } else {
               commonUtil.showToast(translate("Something went wrong while sending the email."))
@@ -604,7 +604,7 @@ async function openProofOfDeliveryModal(orderData: any, isViewModeOnly: any) {
       // Send the proof of delivery email
       const resp = await orderStore.sendPickupNotification(data.proofOfDeliveryData);
 
-      if (commonUtil.hasError(resp) || resp.data?.success === "false") {
+      if (commonUtil.hasError(resp) || resp.data?.success === false) {
         logger.error("Pickup notification failed:", resp);
         commonUtil.showToast(translate("Unable to save the details. Please try again."));
       } else {

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -606,7 +606,7 @@ async function openProofOfDeliveryModal(orderData: any, isViewModeOnly: any) {
 
       if (commonUtil.hasError(resp) || resp.data?.success === false) {
         logger.error("Pickup notification failed:", resp);
-        commonUtil.showToast(translate("Unable to save the details. Please try again."));
+        commonUtil.showToast(translate("Details have been successfully saved, but failed to send email notification to the customer due to missing configuration."));
       } else {
         await useOrderStore().getCommunicationEvents({ orders: [order.value] });
         commonUtil.showToast(translate("Details have been successfully saved, and an email has been sent to the customer."));

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -412,7 +412,7 @@ async function sendReadyForPickupEmail(orderData: any) {
         handler: async () => {
           try {
             const resp = await orderStore.sendPickupScheduledNotification({ shipmentId: orderData.shipmentId });
-            if (!commonUtil.hasError(resp) && resp.data?.success === true) {
+            if (!commonUtil.hasError(resp) && resp.data?.success) {
               commonUtil.showToast(translate("Email sent successfully"))
             } else {
               commonUtil.showToast(translate("Something went wrong while sending the email."))
@@ -604,7 +604,7 @@ async function openProofOfDeliveryModal(orderData: any, isViewModeOnly: any) {
       // Send the proof of delivery email
       const resp = await orderStore.sendPickupNotification(data.proofOfDeliveryData);
 
-      if (commonUtil.hasError(resp) || resp.data?.success === false) {
+      if (commonUtil.hasError(resp) || !resp.data?.success) {
         logger.error("Pickup notification failed:", resp);
         commonUtil.showToast(translate("Details have been successfully saved, but failed to send email notification to the customer due to missing configuration."));
       } else {

--- a/src/views/ShipToStoreOrders.vue
+++ b/src/views/ShipToStoreOrders.vue
@@ -258,7 +258,7 @@ const scheduleOrderForPickup = async (shipmentId: string, order: any) => {
       if (isLastShipGroup) {
         try {
           const emailResp = await orderStore.sendPickupScheduledNotification({ shipmentId });
-          if (!commonUtil.hasError(emailResp) && emailResp.data?.success === "true") {
+          if (!commonUtil.hasError(emailResp) && emailResp.data?.success === true) {
             commonUtil.showToast(translate('Order marked as ready for pickup, an email notification has been sent to the customer'));
           }
         } catch (error) {
@@ -319,7 +319,7 @@ const handoverOrder = async (shipmentId: string, order: any) => {
       if (isLastShipGroup) {
         try {
           const emailResp = await orderStore.sendHandoverNotification({ shipmentId });
-          if (!commonUtil.hasError(emailResp) && emailResp.data?.success === "true") {
+          if (!commonUtil.hasError(emailResp) && emailResp.data?.success === true) {
             commonUtil.showToast(translate('Order handed over successfully and order completion email has been sent'));
           } else {
             logger.error('Error sending handover notification:', emailResp);
@@ -372,7 +372,7 @@ const sendReadyForPickupEmail = async (order: any) => {
       handler: async () => {
         try {
           const resp = await orderStore.sendPickupScheduledNotification({ shipmentId: order.shipmentId });
-          if (!commonUtil.hasError(resp) && resp.data?.success === "true") {
+          if (!commonUtil.hasError(resp) && resp.data?.success === true) {
             commonUtil.showToast(translate("Email sent successfully"));
           } else {
             commonUtil.showToast(translate("Something went wrong while sending the email."));
@@ -401,7 +401,7 @@ const openProofOfDeliveryModal = async (order: any, isViewModeOnly: any) => {
     emitter.emit("presentLoader");
     try {
       const resp = await orderStore.sendPickupNotification(data.proofOfDeliveryData);
-      if (commonUtil.hasError(resp) || resp.data?.success === "false"){
+      if (commonUtil.hasError(resp) || resp.data?.success === false){
         logger.error("Pickup notification failed:", resp);
         commonUtil.showToast(translate("Unable to save the details. Please try again."));
       } else {

--- a/src/views/ShipToStoreOrders.vue
+++ b/src/views/ShipToStoreOrders.vue
@@ -258,7 +258,7 @@ const scheduleOrderForPickup = async (shipmentId: string, order: any) => {
       if (isLastShipGroup) {
         try {
           const emailResp = await orderStore.sendPickupScheduledNotification({ shipmentId });
-          if (!commonUtil.hasError(emailResp)) {
+          if (!commonUtil.hasError(emailResp) && emailResp.data?.success === "true") {
             commonUtil.showToast(translate('Order marked as ready for pickup, an email notification has been sent to the customer'));
           }
         } catch (error) {
@@ -319,7 +319,7 @@ const handoverOrder = async (shipmentId: string, order: any) => {
       if (isLastShipGroup) {
         try {
           const emailResp = await orderStore.sendHandoverNotification({ shipmentId });
-          if (!commonUtil.hasError(emailResp)) {
+          if (!commonUtil.hasError(emailResp) && emailResp.data?.success === "true") {
             commonUtil.showToast(translate('Order handed over successfully and order completion email has been sent'));
           } else {
             logger.error('Error sending handover notification:', emailResp);
@@ -372,7 +372,7 @@ const sendReadyForPickupEmail = async (order: any) => {
       handler: async () => {
         try {
           const resp = await orderStore.sendPickupScheduledNotification({ shipmentId: order.shipmentId });
-          if (!commonUtil.hasError(resp)) {
+          if (!commonUtil.hasError(resp) && resp.data?.success === "true") {
             commonUtil.showToast(translate("Email sent successfully"));
           } else {
             commonUtil.showToast(translate("Something went wrong while sending the email."));
@@ -401,7 +401,7 @@ const openProofOfDeliveryModal = async (order: any, isViewModeOnly: any) => {
     emitter.emit("presentLoader");
     try {
       const resp = await orderStore.sendPickupNotification(data.proofOfDeliveryData);
-      if (commonUtil.hasError(resp)) {
+      if (commonUtil.hasError(resp) || resp.data?.success === "false"){
         logger.error("Pickup notification failed:", resp);
         commonUtil.showToast(translate("Unable to save the details. Please try again."));
       } else {

--- a/src/views/ShipToStoreOrders.vue
+++ b/src/views/ShipToStoreOrders.vue
@@ -260,6 +260,8 @@ const scheduleOrderForPickup = async (shipmentId: string, order: any) => {
           const emailResp = await orderStore.sendPickupScheduledNotification({ shipmentId });
           if (!commonUtil.hasError(emailResp) && emailResp.data?.success === true) {
             commonUtil.showToast(translate('Order marked as ready for pickup, an email notification has been sent to the customer'));
+          } else {
+            commonUtil.showToast(translate('Order marked as ready for pickup but something went wrong while sending the email notification'));
           }
         } catch (error) {
           logger.error('Error sending pickup scheduled notification:', error);

--- a/src/views/ShipToStoreOrders.vue
+++ b/src/views/ShipToStoreOrders.vue
@@ -258,7 +258,7 @@ const scheduleOrderForPickup = async (shipmentId: string, order: any) => {
       if (isLastShipGroup) {
         try {
           const emailResp = await orderStore.sendPickupScheduledNotification({ shipmentId });
-          if (!commonUtil.hasError(emailResp) && emailResp.data?.success === true) {
+          if (!commonUtil.hasError(emailResp) && emailResp.data?.success) {
             commonUtil.showToast(translate('Order marked as ready for pickup, an email notification has been sent to the customer'));
           } else {
             commonUtil.showToast(translate('Order marked as ready for pickup but something went wrong while sending the email notification'));
@@ -321,7 +321,7 @@ const handoverOrder = async (shipmentId: string, order: any) => {
       if (isLastShipGroup) {
         try {
           const emailResp = await orderStore.sendHandoverNotification({ shipmentId });
-          if (!commonUtil.hasError(emailResp) && emailResp.data?.success === true) {
+          if (!commonUtil.hasError(emailResp) && emailResp.data?.success) {
             commonUtil.showToast(translate('Order handed over successfully and order completion email has been sent'));
           } else {
             logger.error('Error sending handover notification:', emailResp);
@@ -374,7 +374,7 @@ const sendReadyForPickupEmail = async (order: any) => {
       handler: async () => {
         try {
           const resp = await orderStore.sendPickupScheduledNotification({ shipmentId: order.shipmentId });
-          if (!commonUtil.hasError(resp) && resp.data?.success === true) {
+          if (!commonUtil.hasError(resp) && resp.data?.success) {
             commonUtil.showToast(translate("Email sent successfully"));
           } else {
             commonUtil.showToast(translate("Something went wrong while sending the email."));
@@ -403,9 +403,9 @@ const openProofOfDeliveryModal = async (order: any, isViewModeOnly: any) => {
     emitter.emit("presentLoader");
     try {
       const resp = await orderStore.sendPickupNotification(data.proofOfDeliveryData);
-      if (commonUtil.hasError(resp) || resp.data?.success === false){
+      if (commonUtil.hasError(resp) || !resp.data?.success){
         logger.error("Pickup notification failed:", resp);
-        commonUtil.showToast(translate("Unable to save the details. Please try again."));
+        commonUtil.showToast(translate("Details have been successfully saved, but failed to send email notification to the customer due to missing configuration."));
       } else {
         await (useOrderStore() as any).getCommunicationEvents({ orders: [order] });
         commonUtil.showToast(translate("Details have been successfully saved, and an email has been sent to the customer."));


### PR DESCRIPTION
### Related Issues

Closes #801

Related OMS changes:
- PR: hotwax/oms#843
- Issue: hotwax/oms#835

### Short Description and Why It's Useful

This PR updates the BOPIS app to validate the `success` flag returned by the `send#EmailOnOrderEvents` API response instead of relying solely on the HTTP response status.

As part of the related OMS changes, missing `ProductStoreEmailSetting` is now treated as a warning instead of a service error. When the email configuration for a product store is unavailable, the API returns `200 OK` with `success=false` rather than failing the request. Actual service failures or failures in chained services continue to return service errors.

This change:
- Validates the `success` flag when the notification API responds with `200 OK`.
- Displays success messages only when `success=true`.
- Treats `success=false` as a notification failure and follows the existing error handling flow.
- Preserves the existing error handling for actual service failures.

This prevents misleading success messages while keeping `ProductStoreEmailSetting` an optional configuration rather than a mandatory requirement.

### Testing

- Verified the changes locally by calling the local Maarg instance.
- Validated the handling of both `success=true` and `success=false` responses.
- Confirmed that actual service failures continue to follow the existing error handling flow.