### PR TITLE
Fix: Use product store settings resource on BOPIS settings page (#813)

### DIFF
--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -408,26 +408,22 @@ export const useProductStore = defineStore('productStore', {
       const productStoreSettings = {} as any
 
       if (productStoreId) {
-        const payload = {
-          productStoreId,
-          settingTypeEnumId: Object.keys(defaultProductStoreSettings),
-          settingTypeEnumId_op: "in",
-          pageIndex: 0,
-          pageSize: 50
-        }
         try {
           const resp = await api({
-            url: `/oms/dataDocumentView`,
-            method: "POST",
-            data: {
-              dataDocumentId: "ProductStoreSetting",
-              customParametersMap: payload
+            url: `/admin/productStores/${productStoreId}/settings`,
+            method: "GET",
+            params: {
+              settingTypeEnumId: Object.keys(defaultProductStoreSettings),
+              settingTypeEnumId_op: "in",
+              pageSize: 50
             }
           }) as any
 
-          resp?.data?.entityValueList?.forEach((productSetting: any) => {
-            productStoreSettings[productSetting.settingTypeEnumId] = productSetting.settingValue
-          })
+          if (!commonUtil.hasError(resp) && resp.data) {
+            resp.data.forEach((productSetting: any) => {
+              productStoreSettings[productSetting.settingTypeEnumId] = productSetting.settingValue
+            })
+          }
         } catch (error) {
           logger.error("Failed to fetch settings", error)
         }


### PR DESCRIPTION
## Description

The BOPIS Settings page was fetching product store settings using the `dataDocumentView` API with the `ProductStoreSetting` DataDocument. Since this DataDocument is not available in the target environment, the request returned a `400 Bad Request`, preventing the settings from loading.

This change updates the application to fetch product store settings using the dedicated Product Store Settings REST resource instead.

### Changes

- Updated `fetchProductStoreSettings` to use:
  ```
  GET /admin/productStores/{productStoreId}/settings
  ```
- Removed dependency on the `ProductStoreSetting` DataDocument.
- Updated the response parsing logic to work with the REST API response.

### Related Issue

Closes #813

### Testing

- Verified the Settings page loads successfully.
- Confirmed the request to:
  ```
  GET /admin/productStores/STORE/settings
  ```
  returns `200 OK`.
- Verified all product store settings are displayed correctly.