### PR TITLE
Fix: Prevent bottom navigation from overlapping order actions on desktop view (#815)

### DIFF
--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -117,4 +117,10 @@ main {
   grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
   align-items: start;
 }
+
+@media (min-width: 991px) {
+  ion-content {
+    --padding-bottom: 80px;
+  }
+}
 </style>

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -655,5 +655,9 @@ ion-item {
   ion-header > div {
     display: flex;
   }
+
+  ion-content {
+    --padding-bottom: 80px;
+  }
 }
 </style>

--- a/src/views/ShipToStoreOrders.vue
+++ b/src/views/ShipToStoreOrders.vue
@@ -458,5 +458,9 @@ onUnmounted(() => {
   ion-header > div {
     display: flex;
   }
+
+  ion-content {
+    --padding-bottom: 80px;
+  }
 }
 </style>


### PR DESCRIPTION
## Description

Fixes a UI issue on the BOPIS Orders page where the bottom navigation overlapped the action buttons of the last order card on desktop/laptop viewports. This prevented users from accessing actions such as **Ready for Pickup** and **Reject** after scrolling to the bottom of the list.

This change adds sufficient bottom spacing to the scrollable content so that the final card remains fully visible above the floating bottom navigation.

## Changes Made

- Added bottom padding to the scrollable content on desktop/laptop viewports (`min-width: 991px`) to prevent the floating bottom navigation from overlapping page content.
- Applied the update to:
  - `Orders.vue`
  - `ShipToStoreOrders.vue`
  - `Catalog.vue`
- Preserved the existing mobile layout, where the bottom navigation remains in the normal document flow.

## Related Issue

Closes #815

## Verification

- Verified on desktop/laptop viewports (`>= 991px`) that the last order card scrolls completely above the bottom navigation.
- Confirmed that action buttons such as **Ready for Pickup** and **Reject** are fully visible and clickable.
- Verified that the mobile layout (`< 991px`) continues to behave as expected without any regressions.