### PR TITLE
Fix: Resolve Ready for Pickup loading issue caused by ensurePartyRole API (#817)

### DIFF
--- a/src/store/order.ts
+++ b/src/store/order.ts
@@ -1464,7 +1464,7 @@ export const useOrderStore = defineStore('order', {
     },
     async ensurePartyRole(payload: any): Promise<any> {
       return api({
-        url: "service/ensurePartyRole",
+        url: `oms/parties/${payload.partyId}/roles`,
         method: "post",
         data: payload
       });

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -738,13 +738,22 @@ async function createPicklist(orderRef: any, selectedPicker: any) {
 }
 
 async function printPicklist(orderRef: any, shipGroup: any) {
+  if (shipGroup.picklistId) {
+    await useOrderStore().printPicklist(shipGroup.picklistId);
+    return;
+  }
   if(!isTrackingEnabled.value) {
-    const resp = await useOrderStore().ensurePartyRole({
-      partyId: "_NA_",
-      roleTypeId: "WAREHOUSE_PICKER",
-    })
-    if(commonUtil.hasError(resp)) {
-      commonUtil.showToast(translate("Something went wrong"))
+    try {
+      const resp = await useOrderStore().ensurePartyRole({
+        partyId: "_NA_",
+        roleTypeId: "WAREHOUSE_PICKER",
+      })
+      if(commonUtil.hasError(resp)) {
+        throw resp.data;
+      }
+    } catch (error) {
+      commonUtil.showToast(translate("Something went wrong. Picklist can not be created."));
+      logger.error(error)
       return;
     }
     await createPicklist(orderRef, "_NA_")
@@ -811,16 +820,22 @@ async function readyForPickup(orderData: any, shipGroup: any) {
         handler: async () => {
           alert.dismiss();
           emitter.emit("presentLoader", { message: "Loading...", backdropDismiss: false });
-          if (!shipGroup.shipmentId) {
-            await printPicklist(orderData, shipGroup)
-          }
-          await useOrderStore().packShipGroupItems({ order: orderData, shipGroup }).then(async (resp: any) => {
-            if (!commonUtil.hasError(resp)) {
-              await getOrderDetail(props.orderId, props.shipGroupSeqId, props.orderType);
-              prepareOrderTimeline({ statusId: "SHIPMENT_PACKED" });
+          try {
+            if (!shipGroup.shipmentId) {
+              await printPicklist(orderData, shipGroup)
             }
-          })
-          emitter.emit("dismissLoader");
+            if (shipGroup.shipmentId || shipGroup.picklistId) {
+              const resp = await useOrderStore().packShipGroupItems({ order: orderData, shipGroup });
+              if (!commonUtil.hasError(resp)) {
+                await getOrderDetail(props.orderId, props.shipGroupSeqId, props.orderType);
+                prepareOrderTimeline({ statusId: "SHIPMENT_PACKED" });
+              }
+            }
+          } catch (err) {
+            logger.error("Error during ready for pickup:", err);
+          } finally {
+            emitter.emit("dismissLoader");
+          }
         }
       }]
     });

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -345,13 +345,22 @@ async function readyForPickup(orderData: any, shipGroup: any) {
         handler: async () => {
           alert.dismiss();
           emitter.emit("presentLoader", { message: "Loading...", backdropDismiss: false });
-          let orderIndex;
-          if (!shipGroup.shipmentId) {
-            await printPicklist(orderData, shipGroup)
-            orderIndex = orders.value.findIndex((o: any) => o.orderId === orderData.orderId);
+          try {
+            let orderIndex;
+            if (!shipGroup.shipmentId) {
+              await printPicklist(orderData, shipGroup)
+              orderIndex = orders.value.findIndex((o: any) => o.orderId === orderData.orderId);
+            }
+            const currentOrder = orderIndex !== undefined && orderIndex >= 0 ? orders.value[orderIndex] : orderData;
+            const currentShipGroup = orderIndex !== undefined && orderIndex >= 0 ? orders.value[orderIndex].shipGroup : shipGroup;
+            if (currentShipGroup?.shipmentId || currentShipGroup?.picklistId) {
+              await useOrderStore().packShipGroupItems({ order: currentOrder, shipGroup: currentShipGroup });
+            }
+          } catch (err) {
+            logger.error("Error during ready for pickup:", err);
+          } finally {
+            emitter.emit("dismissLoader");
           }
-          await useOrderStore().packShipGroupItems({ order: orderIndex >= 0 ? orders.value[orderIndex] : orderData, shipGroup: orderIndex >= 0 ? orders.value[orderIndex].shipGroup : shipGroup })
-          emitter.emit("dismissLoader");
         }
       }]
     });


### PR DESCRIPTION
## Related Issue

Closes #817

## Description

Fixes an issue where clicking **Ready for Pickup** on the Orders and Order Detail pages could leave the application in an infinite loading state.

The issue occurred because the application was invoking an outdated `ensurePartyRole` REST endpoint. When the request failed, the loading overlay was not dismissed, preventing users from continuing with the workflow.

## Root Cause

- `ensurePartyRole` was calling the deprecated REST endpoint:
  ```
  POST /service/ensurePartyRole
  ```
  which returned `404 Not Found`.
- Errors during the picklist creation flow were not handled consistently, causing the loading overlay to remain visible indefinitely.
- `packShipGroupItems()` could still be invoked even when the shipment or picklist had not been created successfully.

## Changes Made

- Updated `ensurePartyRole` to use the correct REST resource:
  ```
  POST /oms/parties/{partyId}/roles
  ```
- Wrapped the **Ready for Pickup** workflow in `try...catch...finally` blocks to ensure the loader is always dismissed.
- Added validation to invoke `packShipGroupItems()` only when a valid shipment or picklist exists.
- Improved error handling during the picklist creation flow.

## Verification

- Verified `ensurePartyRole` is successfully invoked through:
  ```
  POST /oms/parties/{partyId}/roles
  ```
- Verified the **Ready for Pickup** workflow on both the Orders and Order Detail pages.
- Verified the loading indicator is dismissed correctly on both successful and failed requests.
- Verified no infinite loading occurs when the API request fails.