### PR TITLE
Improved: Centralized app permissions into a single authorization actions file and removed unused casl and boon-js dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@capacitor/android": "catalog:",
     "@capacitor/core": "catalog:",
     "@capacitor/ios": "catalog:",
-    "@casl/ability": "^6.0.0",
     "@ionic/core": "catalog:",
     "@ionic/vue": "catalog:",
     "@ionic/vue-router": "catalog:",

--- a/src/authorization/actions.ts
+++ b/src/authorization/actions.ts
@@ -1,0 +1,30 @@
+/**
+ * App actions mapped to the server permissions they require.
+ *
+ * Views, components and routes should always refer to an action from this file instead of
+ * hardcoding a server permission, so that a permission change is a one line change here.
+ *
+ * The value is the permission expression evaluated by `hasPermission` of the user store.
+ * It supports the `OR` and `AND` operators, and an empty value means the action is allowed
+ * for every logged in user.
+ */
+export default {
+  APP_ORDERS_VIEW: "",
+  APP_CATALOG_VIEW: "",
+  APP_ORDER_DETAIL_VIEW: "",
+  APP_PRODUCT_DETAIL_VIEW: "",
+  APP_ORDER_UPDATE: "",
+  APP_CANCEL_BOPIS_ORDER: "ORD_SALES_ORDER_CNCL",
+  APP_REQUEST_TRANSFER_UPDATE: "BOPIS_REQUEST_TRANSFER_UPDATE",
+  APP_PROOF_OF_DELIVERY_PREF_UPDATE: "BOPIS_POD_UPDATE",
+  APP_STOREFULFILLMENT_ADMIN: "STOREFULFILLMENT_ADMIN",
+  APP_PRODUCT_IDENTIFIER_UPDATE: "STOREFULFILLMENT_ADMIN",
+  APP_RF_CONFIG_UPDATE: "COMMON_ADMIN",
+  APP_PARTIAL_ORDER_REJECTION_CONFIG_UPDATE: "COMMON_ADMIN",
+  APP_SHOW_SHIPPING_ORD_PREF_UPDATE: "COMMON_ADMIN",
+  APP_PRINT_PACKING_SLIP_PREF_UPDATE: "COMMON_ADMIN",
+  APP_ENABLE_TRACKING_PREF_UPDATE: "COMMON_ADMIN",
+  APP_PRINT_PICKLIST_PREF_UPDATE: "COMMON_ADMIN",
+  APP_PWA_STANDALONE_ACCESS: "COMMON_ADMIN",
+  APP_COMMERCE_VIEW: "COMMERCEUSER_VIEW"
+} as const satisfies Record<string, string>

--- a/src/components/DxpProductIdentifier.vue
+++ b/src/components/DxpProductIdentifier.vue
@@ -11,12 +11,12 @@
       {{ 'Choosing a product identifier allows you to view products with your preferred identifiers.' }}
     </ion-card-content>
 
-    <ion-item :disabled="!userStore.hasPermission('STOREFULFILLMENT_ADMIN')">
+    <ion-item :disabled="!userStore.hasPermission(Actions.APP_PRODUCT_IDENTIFIER_UPDATE)">
       <ion-select :label="translate('Primary')" interface="popover" :placeholder="'primary identifier'" :value="productIdentificationPref.primaryId" @ionChange="setProductIdentificationPref($event.detail.value, 'primaryId')">
         <ion-select-option v-for="identification in productIdentificationOptions" :key="identification.goodIdentificationTypeId" :value="identification.goodIdentificationTypeId" >{{ identification.description ? identification.description : identification.goodIdentificationTypeId }}</ion-select-option>
       </ion-select>
     </ion-item>
-    <ion-item lines="none" :disabled="!userStore.hasPermission('STOREFULFILLMENT_ADMIN')">
+    <ion-item lines="none" :disabled="!userStore.hasPermission(Actions.APP_PRODUCT_IDENTIFIER_UPDATE)">
       <ion-select :label="translate('Secondary')" interface="popover" :placeholder="'secondary identifier'" :value="productIdentificationPref.secondaryId" @ionChange="setProductIdentificationPref($event.detail.value, 'secondaryId')">
         <ion-select-option v-for="identification in productIdentificationOptions" :key="identification.goodIdentificationTypeId" :value="identification.goodIdentificationTypeId" >{{ identification.description ? identification.description : identification.goodIdentificationTypeId }}</ion-select-option>
         <ion-select-option value="">{{ "None" }}</ion-select-option>
@@ -49,6 +49,7 @@ import { useUserStore } from '@/store/user'
 import { computed, onMounted } from 'vue';
 import { commonUtil, DxpShopifyImg, translate } from "@common";
 import { shuffleOutline } from "ionicons/icons";
+import Actions from "@/authorization/actions";
 
 const productStore = useProductStore();
 const userStore = useUserStore()

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -10,6 +10,7 @@ import { translate, commonUtil, ShopifyLogin, ShopifyAppInstall, Login } from '@
 import { useAuth } from "@common/composables/useAuth";
 import { useUserStore } from '@/store/user'
 import { versionInfoUtil } from '@common/utils/versionInfoUtil'
+import Actions from "@/authorization/actions"
 
 const authGuard = async (to: any, from: any, next: any) => {
   const { isAuthenticated } = useAuth()
@@ -41,14 +42,14 @@ const routes: Array<RouteRecordRaw> = [
         path: 'orders',
         component: () => import('@/views/Orders.vue'),
         meta: {
-          permissionId: ""
+          permissionId: Actions.APP_ORDERS_VIEW
         }
       },
       {
         path: 'catalog',
         component: () => import('@/views/Catalog.vue'),
         meta: {
-          permissionId: ""
+          permissionId: Actions.APP_CATALOG_VIEW
         }
       },
       {
@@ -58,7 +59,7 @@ const routes: Array<RouteRecordRaw> = [
     ],
     beforeEnter: authGuard,
     meta: {
-      permissionId: ""
+      permissionId: Actions.APP_ORDERS_VIEW
     }
   },
   {
@@ -73,7 +74,7 @@ const routes: Array<RouteRecordRaw> = [
     beforeEnter: authGuard,
     props: true,
     meta: {
-      permissionId: ""
+      permissionId: Actions.APP_ORDER_DETAIL_VIEW
     }
   },
   {
@@ -82,7 +83,7 @@ const routes: Array<RouteRecordRaw> = [
     component: ProductDetail,
     beforeEnter: authGuard,
     meta: {
-      permissionId: ""
+      permissionId: Actions.APP_PRODUCT_DETAIL_VIEW
     }
   },
   {

--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { api, commonUtil, useEmbeddedAppStore, logger, translate, useSolrSearch } from '@common'
 import { useUserStore } from '@/store/user'
+import Actions from "@/authorization/actions"
 const defaultProductStoreSettings = JSON.parse(import.meta.env.VITE_DEFAULT_PRODUCT_STORE_SETTINGS as string || '{}')
 
 const getProductStoreSettingValue = (settings: any, settingTypeEnumId: string) => {
@@ -121,7 +122,7 @@ export const useProductStore = defineStore('productStore', {
     async fetchUserFacilities() {
       const userStore = useUserStore();
       const partyId = userStore.getUserProfile?.partyId;
-      const isAdminUser = userStore.hasPermission("STOREFULFILLMENT_ADMIN");
+      const isAdminUser = userStore.hasPermission(Actions.APP_STOREFULFILLMENT_ADMIN);
       const facilityGroupId = "OMS_FULFILLMENT";
 
       this.currentFacility = {

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -5,16 +5,16 @@
         <ion-back-button default-href="/" slot="start" />
         <ion-title>{{ translate("Order details") }}</ion-title>
         <ion-buttons slot="end">
-          <ion-button data-testid="resendmail-button" v-if="orderType === 'packed' && order.shipGroup?.shipmentMethodTypeId === 'STOREPICKUP'" :disabled="!order?.orderId || !useUserStore().hasPermission('') || order.handovered || order.shipped" @click="sendReadyForPickupEmail(order)">
+          <ion-button data-testid="resendmail-button" v-if="orderType === 'packed' && order.shipGroup?.shipmentMethodTypeId === 'STOREPICKUP'" :disabled="!order?.orderId || !useUserStore().hasPermission(Actions.APP_ORDER_UPDATE) || order.handovered || order.shipped" @click="sendReadyForPickupEmail(order)">
             <ion-icon slot="icon-only" :icon="mailOutline" />
           </ion-button>
           <ion-button data-testid="rejection-history-button" :disabled="!order?.orderId" @click="openOrderItemRejHistoryModal()">
             <ion-icon slot="icon-only" :icon="timeOutline" />
           </ion-button>
-          <ion-button data-testid="print-picklist-button" v-if="orderType === 'open' && isPrintPicklistsEnabled" :disabled="!order?.orderId || !useUserStore().hasPermission('') || order.handovered || order.shipped || !order.shipGroup?.items?.length"  @click="printPicklist(order, order.shipGroup)">
+          <ion-button data-testid="print-picklist-button" v-if="orderType === 'open' && isPrintPicklistsEnabled" :disabled="!order?.orderId || !useUserStore().hasPermission(Actions.APP_ORDER_UPDATE) || order.handovered || order.shipped || !order.shipGroup?.items?.length"  @click="printPicklist(order, order.shipGroup)">
             <ion-icon slot="icon-only" :icon="printOutline" />
           </ion-button>
-          <ion-button data-testid="packing-slip-button" v-else-if="orderType === 'packed' && isPrintPackingSlipEnabled" :class="order.shipGroup?.shipmentMethodTypeId !== 'STOREPICKUP' ? 'ion-hide-md-up' : ''" :disabled="!order?.orderId || !useUserStore().hasPermission('') || order.handovered || order.shipped || !order.shipGroup?.items?.length" @click="order.shipGroup.shipmentMethodTypeId === 'STOREPICKUP' ? printPackingSlip(order) : printShippingLabelAndPackingSlip(order)">
+          <ion-button data-testid="packing-slip-button" v-else-if="orderType === 'packed' && isPrintPackingSlipEnabled" :class="order.shipGroup?.shipmentMethodTypeId !== 'STOREPICKUP' ? 'ion-hide-md-up' : ''" :disabled="!order?.orderId || !useUserStore().hasPermission(Actions.APP_ORDER_UPDATE) || order.handovered || order.shipped || !order.shipGroup?.items?.length" @click="order.shipGroup.shipmentMethodTypeId === 'STOREPICKUP' ? printPackingSlip(order) : printShippingLabelAndPackingSlip(order)">
             <ion-icon slot="icon-only" :icon="printOutline" />
           </ion-button>
         </ion-buttons>
@@ -53,7 +53,7 @@
               <h1 data-testid="order-name-tag">{{ order.orderName }}</h1>
               <p data-testid="order-id-tag">{{ order.orderId }}</p>
             </ion-label>
-            <ion-chip data-testid="edit-picker-chip" :disabled="!useUserStore().hasPermission('') || order.handovered || order.shipped || order.rejected || order.cancelled" v-if="order.pickers && (orderType === 'open' || orderType === 'packed') && isTrackingEnabled" outline slot="end" @click="editPicker(order)">
+            <ion-chip data-testid="edit-picker-chip" :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE) || order.handovered || order.shipped || order.rejected || order.cancelled" v-if="order.pickers && (orderType === 'open' || orderType === 'packed') && isTrackingEnabled" outline slot="end" @click="editPicker(order)">
               <ion-icon :icon="personOutline"/>
               <ion-label>{{ order.pickers }}</ion-label>
             </ion-chip>
@@ -104,7 +104,7 @@
                       <ion-label>{{ getCancelReasonDescription(item.cancelReason) }}</ion-label>
                       <ion-icon :icon="caretDownOutline"/>
                     </ion-chip>
-                    <ion-button data-testid="select-cancel-item-button" v-else slot="end" color="danger" fill="clear" size="small" :disabled="!useUserStore().hasPermission('ORD_SALES_ORDER_CNCL')" @click.stop="openCancelReasonPopover($event, item, order)">
+                    <ion-button data-testid="select-cancel-item-button" v-else slot="end" color="danger" fill="clear" size="small" :disabled="!useUserStore().hasPermission(Actions.APP_CANCEL_BOPIS_ORDER)" @click.stop="openCancelReasonPopover($event, item, order)">
                       {{ translate("Cancel") }}
                     </ion-button>
                   </template>
@@ -181,24 +181,24 @@
           </template>
 
           <ion-item lines="none" v-if="orderType === 'open' && order.shipGroup?.items?.length">
-            <ion-button data-testid="ready-pickup-button" size="default" :disabled="!useUserStore().hasPermission('') || order.readyToHandover || order.readyToShip || order.rejected || hasRejectedItems" @click="readyForPickup(order, order.shipGroup)">
+            <ion-button data-testid="ready-pickup-button" size="default" :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE) || order.readyToHandover || order.readyToShip || order.rejected || hasRejectedItems" @click="readyForPickup(order, order.shipGroup)">
               <ion-icon slot="start" :icon="bagCheckOutline"/>
               {{ order?.shipGroup.shipmentMethodTypeId === 'STOREPICKUP' ? translate("Ready for pickup") : translate("Ready to ship") }}
             </ion-button>
-            <ion-button data-testid="submit-rejected-items-button" v-if="!isRequestTransferEnabled" size="default" :disabled="!useUserStore().hasPermission('') || order.readyToHandover || order.readyToShip || order.rejected || !hasRejectedItems" color="danger" fill="outline" @click="rejectOrder()">
+            <ion-button data-testid="submit-rejected-items-button" v-if="!isRequestTransferEnabled" size="default" :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE) || order.readyToHandover || order.readyToShip || order.rejected || !hasRejectedItems" color="danger" fill="outline" @click="rejectOrder()">
               {{ translate("Reject Items") }}
             </ion-button>
-            <ion-button fill="outline" data-testid="request-transfer-button" v-if="isRequestTransferEnabled" size="default" color="warning" :disabled="!useUserStore().hasPermission('') || !canRequestTransfer(order)" @click="confirmRequestTransfer(order)">
+            <ion-button fill="outline" data-testid="request-transfer-button" v-if="isRequestTransferEnabled" size="default" color="warning" :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE) || !canRequestTransfer(order)" @click="confirmRequestTransfer(order)">
               <ion-icon slot="start" :icon="swapHorizontalOutline"/>
               {{ translate("Request Transfer") }}
             </ion-button>            
           </ion-item>
           <ion-item lines="none" v-else-if="orderType === 'packed' && order.shipGroup?.items?.length" class="ion-hide-md-down">
-            <ion-button data-testid="handover-button" size="default" :disabled="!useUserStore().hasPermission('') || order.handovered || order.shipped || order.cancelled || hasCancelledItems" expand="block" @click="deliverShipment(order)">
+            <ion-button data-testid="handover-button" size="default" :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE) || order.handovered || order.shipped || order.cancelled || hasCancelledItems" expand="block" @click="deliverShipment(order)">
               <ion-icon slot="start" :icon="checkmarkDoneOutline"/>
               {{ order.shipGroup.shipmentMethodTypeId === 'STOREPICKUP' ? translate("Handover") : translate("Ship") }}
             </ion-button>
-            <ion-button data-testid="submit-cancel-items-button" color="danger" size="default" :disabled="!useUserStore().hasPermission('')||!useUserStore().hasPermission('ORD_SALES_ORDER_CNCL') || order.handovered || order.shipped || order.cancelled || !hasCancelledItems" expand="block" fill="outline" @click="cancelOrder(order)">
+            <ion-button data-testid="submit-cancel-items-button" color="danger" size="default" :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE)||!useUserStore().hasPermission(Actions.APP_CANCEL_BOPIS_ORDER) || order.handovered || order.shipped || order.cancelled || !hasCancelledItems" expand="block" fill="outline" @click="cancelOrder(order)">
               {{ translate("Cancel items") }}
             </ion-button>
           </ion-item>
@@ -316,12 +316,12 @@
       </main>
 
       <ion-fab v-if="orderType === 'open' && order?.orderId" class="ion-hide-md-up" vertical="bottom" horizontal="end" slot="fixed" >
-        <ion-fab-button :disabled="!useUserStore().hasPermission('') || order.readyToHandover || order.readyToShip || order.rejected" @click="readyForPickup(order, order.shipGroup)">
+        <ion-fab-button :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE) || order.readyToHandover || order.readyToShip || order.rejected" @click="readyForPickup(order, order.shipGroup)">
           <ion-icon :icon="order.shipGroup.shipmentMethodTypeId === 'STOREPICKUP' ? bagHandleOutline : giftOutline" />
         </ion-fab-button>
       </ion-fab>
       <ion-fab v-else-if="orderType === 'packed' && order?.orderId" class="ion-hide-md-up" vertical="bottom" horizontal="end" slot="fixed" >
-        <ion-fab-button data-testid="handover-fab-button" :disabled="!useUserStore().hasPermission('') || order.handovered || order.shipped || order.cancelled" @click="deliverShipment(order)">
+        <ion-fab-button data-testid="handover-fab-button" :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE) || order.handovered || order.shipped || order.cancelled" @click="deliverShipment(order)">
           <ion-icon :icon="checkmarkDoneOutline" />
         </ion-fab-button>
       </ion-fab>
@@ -351,6 +351,7 @@ import { useOrderStore } from "@/store/order";
 import { useProductStore as useProduct } from "@/store/product";
 import { useStockStore } from "@/store/stock";
 import { useUserStore } from "@/store/user"
+import Actions from "@/authorization/actions"
 
 
 const props = defineProps(['orderType', 'orderId', 'shipGroupSeqId']);

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -55,14 +55,14 @@
             <ProductListItem v-for="item in order.shipGroup.items" :key="item.productId" :item="item" />
                         
             <div class="border-top">
-              <ion-button :data-testid="order.shipGroup.shipmentMethodTypeId === 'STOREPICKUP' ? 'ready-pickup-button' : 'ready-ship-button'" :disabled="!useUserStore().hasPermission('')" fill="clear" @click.stop="readyForPickup(order, order.shipGroup)">
+              <ion-button :data-testid="order.shipGroup.shipmentMethodTypeId === 'STOREPICKUP' ? 'ready-pickup-button' : 'ready-ship-button'" :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE)" fill="clear" @click.stop="readyForPickup(order, order.shipGroup)">
                 {{ order.shipGroup?.shipmentMethodTypeId === 'STOREPICKUP' ? translate("Ready for pickup") : translate("Ready to ship") }}
               </ion-button>
               <div></div>
-              <ion-button data-testid="listpage-reject-button" v-if="order.shipGroup.shipmentMethodTypeId === 'STOREPICKUP' && !isRequestTransferEnabled" color="danger" :disabled="!useUserStore().hasPermission('')" fill="clear" @click.stop="openRejectOrderModal(order)">
+              <ion-button data-testid="listpage-reject-button" v-if="order.shipGroup.shipmentMethodTypeId === 'STOREPICKUP' && !isRequestTransferEnabled" color="danger" :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE)" fill="clear" @click.stop="openRejectOrderModal(order)">
                 {{ translate("Reject") }}
               </ion-button>
-              <ion-button data-testid="listpage-request-transfer-button" v-if="order.shipGroup.shipmentMethodTypeId === 'STOREPICKUP' && isRequestTransferEnabled" color="warning" :disabled="!useUserStore().hasPermission('')" fill="clear" @click.stop="confirmRequestTransfer(order)">
+              <ion-button data-testid="listpage-request-transfer-button" v-if="order.shipGroup.shipmentMethodTypeId === 'STOREPICKUP' && isRequestTransferEnabled" color="warning" :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE)" fill="clear" @click.stop="confirmRequestTransfer(order)">
                 {{ translate("Request Transfer") }}
               </ion-button>
               <ion-button size="default" v-if="isPrintPicklistsEnabled" slot="end" fill="clear" @click.stop="printPicklist(order, order.shipGroup)">
@@ -94,7 +94,7 @@
             <ProductListItem v-for="item in order.items" :key="item.productId" :item="item" :orderId="order.orderId" :customerId="order.customerId" :currencyUom="order.currencyUom" orderType="packed"/>
             <div class="border-top">
 
-              <ion-button data-testid="handover-button" :disabled="!useUserStore().hasPermission('')" fill="clear" @click.stop="deliverShipment(order)">
+              <ion-button data-testid="handover-button" :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE)" fill="clear" @click.stop="deliverShipment(order)">
                 {{ order.shipmentMethodTypeId === 'STOREPICKUP' ? translate("Handover") : translate("Ship") }}
               </ion-button>
               <ion-button size="default" data-testid="packing-slip-button" v-if="isPrintPackingSlipEnabled" fill="clear" slot="end" @click.stop="printPackingSlip(order)">
@@ -162,6 +162,7 @@ import ProofOfDeliveryModal from "@/components/ProofOfDeliveryModal.vue";
 import { useUserStore } from "@/store/user";
 import { useOrderStore } from "@/store/order";
 import { useProductStore } from "@/store/productStore"
+import Actions from "@/authorization/actions"
 
 const queryString = ref('');
 const isScrollingEnabled = ref(false);
@@ -281,7 +282,7 @@ async function getCompletedOrders(vSize?: any, vIndex?: any) {
   const viewSize = vSize ? vSize : import.meta.env.VITE_VIEW_SIZE;
   const viewIndex = vIndex ? vIndex : 0;
   await useOrderStore().fetchCompletedOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (currentFacility.value as any)?.facilityId });
-  if (useUserStore().hasPermission('BOPIS_POD_UPDATE')) await useOrderStore().getCommunicationEvents({ orders: completedOrders.value });
+  if (useUserStore().hasPermission(Actions.APP_PROOF_OF_DELIVERY_PREF_UPDATE)) await useOrderStore().getCommunicationEvents({ orders: completedOrders.value });
 }
 
 function enableScrolling() {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -22,7 +22,7 @@
             </ion-card-header>
           </ion-item>
           <ion-button data-testid="logout-button" v-if="!commonUtil.isAppEmbedded()" color="danger" @click="logout()">{{ translate("Logout") }}</ion-button>
-          <ion-button v-if="!commonUtil.isAppEmbedded()" :standalone-hidden="!useUserStore().hasPermission('COMMON_ADMIN')" fill="outline" @click="goToLaunchpad()">
+          <ion-button v-if="!commonUtil.isAppEmbedded()" :standalone-hidden="!useUserStore().hasPermission(Actions.APP_PWA_STANDALONE_ACCESS)" fill="outline" @click="goToLaunchpad()">
             {{ translate("Go to Launchpad") }}
             <ion-icon slot="end" :icon="openOutline" />
           </ion-button>
@@ -34,7 +34,7 @@
         <h1>{{ translate('OMS') }}</h1>
       </div>
       <section>
-        <DxpOmsInstanceNavigator :is-embedded="commonUtil.isAppEmbedded()" :has-oms-access="useUserStore().hasPermission('COMMERCEUSER_VIEW')"/>
+        <DxpOmsInstanceNavigator :is-embedded="commonUtil.isAppEmbedded()" :has-oms-access="useUserStore().hasPermission(Actions.APP_COMMERCE_VIEW)"/>
         <div data-testid="facility-switcher">
           <DxpFacilitySwitcher @updateFacility="fetchFacilityDependencies" />
         </div>
@@ -51,20 +51,20 @@
             {{ translate('Control what your customers are allowed to edit on their order when they are editing their order on Re-route Fulfillment.') }}
           </ion-card-content>
           <ion-item lines="none">
-            <ion-toggle data-testid="delivery-method-toggle" label-placement="start" :disabled="!useUserStore().hasPermission('COMMON_ADMIN')" :checked="isRerouteSettingEnabled('CUST_DLVRMTHD_UPDATE')" @click.prevent="setBopisProductStoreSettings($event, 'CUST_DLVRMTHD_UPDATE')">{{ translate("Delivery method") }}</ion-toggle>
+            <ion-toggle data-testid="delivery-method-toggle" label-placement="start" :disabled="!useUserStore().hasPermission(Actions.APP_RF_CONFIG_UPDATE)" :checked="isRerouteSettingEnabled('CUST_DLVRMTHD_UPDATE')" @click.prevent="setBopisProductStoreSettings($event, 'CUST_DLVRMTHD_UPDATE')">{{ translate("Delivery method") }}</ion-toggle>
           </ion-item>
           <ion-item lines="none">
-            <ion-toggle data-testid="delivery-address-toggle" label-placement="start" :disabled="!useUserStore().hasPermission('COMMON_ADMIN')" :checked="isRerouteSettingEnabled('CUST_DLVRADR_UPDATE')" @click.prevent="setBopisProductStoreSettings($event, 'CUST_DLVRADR_UPDATE')">{{ translate("Delivery address") }}</ion-toggle>
+            <ion-toggle data-testid="delivery-address-toggle" label-placement="start" :disabled="!useUserStore().hasPermission(Actions.APP_RF_CONFIG_UPDATE)" :checked="isRerouteSettingEnabled('CUST_DLVRADR_UPDATE')" @click.prevent="setBopisProductStoreSettings($event, 'CUST_DLVRADR_UPDATE')">{{ translate("Delivery address") }}</ion-toggle>
           </ion-item>
           <ion-item lines="none">
-            <ion-toggle data-testid="pickup-location-toggle" label-placement="start" :disabled="!useUserStore().hasPermission('COMMON_ADMIN')" :checked="isRerouteSettingEnabled('CUST_PCKUP_UPDATE')" @click.prevent="setBopisProductStoreSettings($event, 'CUST_PCKUP_UPDATE')">{{ translate("Pick up location") }}</ion-toggle>
+            <ion-toggle data-testid="pickup-location-toggle" label-placement="start" :disabled="!useUserStore().hasPermission(Actions.APP_RF_CONFIG_UPDATE)" :checked="isRerouteSettingEnabled('CUST_PCKUP_UPDATE')" @click.prevent="setBopisProductStoreSettings($event, 'CUST_PCKUP_UPDATE')">{{ translate("Pick up location") }}</ion-toggle>
           </ion-item>
           <ion-item lines="none">
             <!-- <p>Uploading order cancelations to Shopify is currently disabled. Order cancelations in HotWax will not be synced to Shopify.</p> -->
-            <ion-toggle data-testid="cancel-order-toggle" label-placement="start" :disabled="!useUserStore().hasPermission('COMMON_ADMIN')" :checked="isRerouteSettingEnabled('CUST_ALLOW_CNCL')" @click.prevent="setBopisProductStoreSettings($event, 'CUST_ALLOW_CNCL')">{{ translate("Cancel order before fulfillment") }}</ion-toggle>
+            <ion-toggle data-testid="cancel-order-toggle" label-placement="start" :disabled="!useUserStore().hasPermission(Actions.APP_RF_CONFIG_UPDATE)" :checked="isRerouteSettingEnabled('CUST_ALLOW_CNCL')" @click.prevent="setBopisProductStoreSettings($event, 'CUST_ALLOW_CNCL')">{{ translate("Cancel order before fulfillment") }}</ion-toggle>
           </ion-item>
           <ion-item lines="none">
-            <ion-toggle data-testid="order-item-split-toggle" label-placement="start" :disabled="!useUserStore().hasPermission('COMMON_ADMIN')" :checked="isRerouteSettingEnabled('CUST_ORD_ITEM_SPLIT')" @click.prevent="setBopisProductStoreSettings($event, 'CUST_ORD_ITEM_SPLIT')">{{ translate("Order item split") }}</ion-toggle>
+            <ion-toggle data-testid="order-item-split-toggle" label-placement="start" :disabled="!useUserStore().hasPermission(Actions.APP_RF_CONFIG_UPDATE)" :checked="isRerouteSettingEnabled('CUST_ORD_ITEM_SPLIT')" @click.prevent="setBopisProductStoreSettings($event, 'CUST_ORD_ITEM_SPLIT')">{{ translate("Order item split") }}</ion-toggle>
           </ion-item>
           <ion-item lines="none">
             <ion-label v-if="Object.keys(getShipmentMethodConfig()).length > 0">
@@ -75,7 +75,7 @@
             <ion-label v-else>
               {{ translate('Shipment method') }}
             </ion-label>
-            <ion-button slot="end" fill="outline" color="dark" :disabled="!useUserStore().hasPermission('COMMON_ADMIN')" @click="openEditShipmentMethodModal()">{{ Object.keys(getShipmentMethodConfig()).length > 0 ? translate('Edit') : translate('Add')}}</ion-button>
+            <ion-button slot="end" fill="outline" color="dark" :disabled="!useUserStore().hasPermission(Actions.APP_RF_CONFIG_UPDATE)" @click="openEditShipmentMethodModal()">{{ Object.keys(getShipmentMethodConfig()).length > 0 ? translate('Edit') : translate('Add')}}</ion-button>
           </ion-item>
         </ion-card>
 
@@ -89,7 +89,7 @@
             {{ translate('Specify whether you reject a BOPIS order partially when any order item inventory is insufficient at the store.') }}
           </ion-card-content>
           <ion-item lines="none">
-            <ion-toggle data-testid="partial-rejection-toggle" label-placement="start" :disabled="!useUserStore().hasPermission('COMMON_ADMIN')" :checked="isProductStoreSettingEnabled('BOPIS_PART_ODR_REJ')" @click.prevent="setBopisProductStoreSettings($event, 'BOPIS_PART_ODR_REJ')">{{ translate("Allow partial rejection") }}</ion-toggle>
+            <ion-toggle data-testid="partial-rejection-toggle" label-placement="start" :disabled="!useUserStore().hasPermission(Actions.APP_PARTIAL_ORDER_REJECTION_CONFIG_UPDATE)" :checked="isProductStoreSettingEnabled('BOPIS_PART_ODR_REJ')" @click.prevent="setBopisProductStoreSettings($event, 'BOPIS_PART_ODR_REJ')">{{ translate("Allow partial rejection") }}</ion-toggle>
           </ion-item>
         </ion-card>
         
@@ -112,7 +112,7 @@
           <ion-card-content>
             {{ translate('Enabling this will show only shipping orders and hide all pickup orders.') }}
           </ion-card-content>
-          <ion-item lines="none" :disabled="!useUserStore().hasPermission('COMMON_ADMIN')">
+          <ion-item lines="none" :disabled="!useUserStore().hasPermission(Actions.APP_SHOW_SHIPPING_ORD_PREF_UPDATE)">
             <ion-toggle data-testid="show-shipping-orders-toggle" label-placement="start" :checked="isProductStoreSettingEnabled('SHOW_SHIPPING_ORDERS')" @click.prevent="setBopisProductStoreSettings($event, 'SHOW_SHIPPING_ORDERS')">{{ translate("Show shipping orders") }}</ion-toggle>
           </ion-item>
         </ion-card>
@@ -126,7 +126,7 @@
           <ion-card-content>
             {{ translate('Packing slips help customer reconcile their order against the delivered items.') }}
           </ion-card-content>
-          <ion-item lines="none" :disabled="!useUserStore().hasPermission('COMMON_ADMIN')">
+          <ion-item lines="none" :disabled="!useUserStore().hasPermission(Actions.APP_PRINT_PACKING_SLIP_PREF_UPDATE)">
             <ion-toggle data-testid="generate-packing-slips-toggle" label-placement="start" :checked="isProductStoreSettingEnabled('PRINT_PACKING_SLIPS')" @click.prevent="setBopisProductStoreSettings($event, 'PRINT_PACKING_SLIPS')">{{ translate("Generate packing slips") }}</ion-toggle>
           </ion-item>
         </ion-card>
@@ -140,15 +140,15 @@
           <ion-card-content>
             {{ translate('Track who picked orders by entering picker IDs when packing an order.') }}
           </ion-card-content>
-          <ion-item :disabled="!useUserStore().hasPermission('COMMON_ADMIN')">
+          <ion-item :disabled="!useUserStore().hasPermission(Actions.APP_ENABLE_TRACKING_PREF_UPDATE)">
             <ion-toggle data-testid="enable-tracking-toggle" label-placement="start" :checked="isProductStoreSettingEnabled('ENABLE_TRACKING')" @click.prevent="setBopisProductStoreSettings($event, 'ENABLE_TRACKING')">{{ translate("Enable tracking") }}</ion-toggle>
           </ion-item>
-          <ion-item lines="none" :disabled="!useUserStore().hasPermission('COMMON_ADMIN')">
+          <ion-item lines="none" :disabled="!useUserStore().hasPermission(Actions.APP_PRINT_PICKLIST_PREF_UPDATE)">
             <ion-toggle data-testid="print-picklists-toggle" label-placement="start" :checked="isProductStoreSettingEnabled('PRINT_PICKLISTS')" @click.prevent="setBopisProductStoreSettings($event, 'PRINT_PICKLISTS')">{{ translate("Print picklists") }}</ion-toggle>
           </ion-item> 
         </ion-card>
 
-        <ion-card v-if="useUserStore().hasPermission('BOPIS_REQUEST_TRANSFER_UPDATE')">
+        <ion-card v-if="useUserStore().hasPermission(Actions.APP_REQUEST_TRANSFER_UPDATE)">
           <ion-card-header>
             <ion-card-title>
               {{ translate("Request Transfer") }}
@@ -157,12 +157,12 @@
           <ion-card-content>
             {{ translate('This will allow store associates to request the item from another store when it is not available in their current stock') }}
           </ion-card-content>
-          <ion-item lines="none" :disabled="!useUserStore().hasPermission('BOPIS_REQUEST_TRANSFER_UPDATE')">
+          <ion-item lines="none" :disabled="!useUserStore().hasPermission(Actions.APP_REQUEST_TRANSFER_UPDATE)">
             <ion-toggle data-testid="request-transfer-toggle" label-placement="start" :checked="isProductStoreSettingEnabled('REQUEST_TRANSFER')" @click.prevent="setBopisProductStoreSettings($event, 'REQUEST_TRANSFER')">{{ translate("Show Request Transfer") }}</ion-toggle>
           </ion-item>
         </ion-card>
 
-        <ion-card v-if="useUserStore().hasPermission('BOPIS_POD_UPDATE')">
+        <ion-card v-if="useUserStore().hasPermission(Actions.APP_PROOF_OF_DELIVERY_PREF_UPDATE)">
           <ion-card-header>
             <ion-card-title>
               {{ translate("Proof of delivery") }}
@@ -216,6 +216,7 @@ import { useOrderStore } from '@/store/order';
 import { useProductStore } from '@/store/productStore';
 import DxpAppVersionInfo from '@/components/DxpAppVersionInfo.vue';
 import { firebaseUtil } from "@/utils/firebaseUtil"
+import Actions from "@/authorization/actions"
 
 const appInfo = ref(import.meta.env.VITE_VERSION_INFO ? JSON.parse(import.meta.env.VITE_VERSION_INFO) : {} as any);
 const appVersion = ref("");

--- a/src/views/ShipToStoreOrders.vue
+++ b/src/views/ShipToStoreOrders.vue
@@ -37,7 +37,7 @@
             <ProductListItem v-for="item in order.items" :key="item.productId" :item="item" :isShipToStoreOrder=true />
 
             <div class="border-top">
-              <ion-button :disabled="!useUserStore().hasPermission('')|| order.shipmentStatusId!='SHIPMENT_SHIPPED'" fill="clear" @click.stop="confirmScheduleOrderForPickup(order)">
+              <ion-button :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE)|| order.shipmentStatusId!='SHIPMENT_SHIPPED'" fill="clear" @click.stop="confirmScheduleOrderForPickup(order)">
                 {{ translate("Arrived") }}
               </ion-button>
             </div>
@@ -60,7 +60,7 @@
             <ProductListItem v-for="item in order.items" :key="item.productId" :item="item" :isShipToStoreOrder=true />
 
             <div class="border-top">
-              <ion-button :disabled="!useUserStore().hasPermission('')" fill="clear" @click.stop="confirmHandoverOrder(order)">
+              <ion-button :disabled="!useUserStore().hasPermission(Actions.APP_ORDER_UPDATE)" fill="clear" @click.stop="confirmHandoverOrder(order)">
                 {{ translate("Handover") }}
               </ion-button>
               <ion-button fill="clear" slot="end" @click="sendReadyForPickupEmail(order)">
@@ -120,6 +120,7 @@ import { commonUtil, emitter, logger, translate } from "@common"
 
 import { DateTime } from 'luxon';
 import ProofOfDeliveryModal from "@/components/ProofOfDeliveryModal.vue";
+import Actions from "@/authorization/actions";
 
 const orderStore = useOrderStore();
 const queryString = ref('');


### PR DESCRIPTION
Introduces `src/authorization/actions.ts`, a single map of app action to the server permission it requires. Views, components and routes now pass an action instead of a hardcoded permission string, so a permission change is a one line change in that file.

Action names are taken from the pre-migration `src/authorization/Rules.ts` wherever a rule matched, so they stay familiar. The value is the permission expression itself, so the user store's `hasPermission` is unchanged.

Also drops `@casl/ability` / `boon-js` from `package.json` — leftovers from the pre-accxui authorization layer that are no longer imported anywhere.

No behaviour change: every call site resolves to the exact same permission expression as before.

> Note: the matching `pnpm-lock.yaml` update lives in the accxui repo and is not part of this PR.