### PR TITLE
Improved: support to display shipping and pickup orders when showShippingOrders setting is enabled(#820)

### DIFF
--- a/src/store/order.ts
+++ b/src/store/order.ts
@@ -47,13 +47,10 @@ export const useOrderStore = defineStore('order', {
   }),
   getters: {
     getOrders: (state) => state.orders,
-    getOpenOrders: (state) => state.open.list,
+    getOpenOrders: (state) => [...state.open.list].sort((a: any, b: any) => b.orderDate - a.orderDate),
     getCurrent: (state) => JSON.parse(JSON.stringify(state.current)),
-    getPackedOrders: (state) => state.packed.list,
-    isPackedOrdersScrollable: (state) => state.packed.list.length > 0 && state.packed.list.length < state.packed.total,
-    isOpenOrdersScrollable: (state) => state.open.list.length > 0 && state.open.list.length < state.open.total,
-    getCompletedOrders: (state) => state.completed.list,
-    isCompletedOrdersScrollable: (state) => state.completed.list.length > 0 && state.completed.list.length < state.completed.total,
+    getPackedOrders: (state) => [...state.packed.list].sort((a: any, b: any) => b.orderDate - a.orderDate),
+    getCompletedOrders: (state) => [...state.completed.list].sort((a: any, b: any) => b.orderDate - a.orderDate),
     getShipToStoreIncomingOrders: (state) => state.shipToStore.incoming.list,
     isShipToStoreIncmngOrdrsScrlbl: (state) => state.shipToStore.incoming.orderCount > 0 && state.shipToStore.incoming.orderCount < state.shipToStore.incoming.total,
     getShipToStoreReadyForPickupOrders: (state) => state.shipToStore.readyForPickup.list,
@@ -240,8 +237,6 @@ export const useOrderStore = defineStore('order', {
       return resp;
     },
     async fetchOpenOrders(params: any) {
-      if (params.viewIndex === 0) emitter.emit("presentLoader");
-
       let queryParams = {
         keyword: params.queryString || '',
         facilityId: params.facilityId,
@@ -249,11 +244,11 @@ export const useOrderStore = defineStore('order', {
         shipmentStatusId: 'SHIPMENT_INPUT,SHIPMENT_PACKED,SHIPMENT_SHIPPED',
         shipmentStatusId_op: 'in',
         shipmentStatusId_not: 'Y',
-        pageSize: import.meta.env.VITE_VIEW_SIZE,
+        pageSize: 200,
         pageIndex: params.viewIndex
       } as any;
 
-      if (useProductStore().isProductStoreSettingEnabled('SHOW_SHIPPING_ORDERS')) {
+      if (params.showShippingOrders) {
         queryParams = {
           shipmentMethodTypeId: 'STOREPICKUP',
           shipmentMethodTypeId_op: 'equals',
@@ -263,6 +258,8 @@ export const useOrderStore = defineStore('order', {
       }
 
       try {
+        let total = 0;
+        do {
         const resp = await api({
           url: "oms/orders/pickup",
           method: "get",
@@ -293,24 +290,17 @@ export const useOrderStore = defineStore('order', {
             };
           });
 
-          const total = resp.data.ordersCount;
-
-          if (params.viewIndex && params.viewIndex > 0) {
-            orders = this.open.list.concat(orders);
-          }
+          total = resp.data.ordersCount;
+          orders = this.open.list.concat(orders);
 
           this.open = { list: orders, total };
-          emitter.emit("dismissLoader");
+          queryParams["pageIndex"]++
         } else {
           this.open = { list: [], total: 0 };
         }
-
-        emitter.emit("dismissLoader");
-        return resp;
-
+        } while(this.open.list.length < total)
       } catch (err) {
         logger.error(err);
-        emitter.emit("dismissLoader");
         commonUtil.showToast(translate("Something went wrong"));
       }
     },
@@ -483,27 +473,26 @@ export const useOrderStore = defineStore('order', {
       this.current = order;
     },
     async fetchPackedOrders(params: any) {
-      if (params.viewIndex === 0) emitter.emit("presentLoader");
       let resp;
 
       const productStore = useProduct();
-
-      const userStore = useUserStore();
       const queryParams = {
         statusId: 'SHIPMENT_PACKED',
         originFacilityId: (useProductStore().getCurrentFacility?.facilityId || ""),
         shipmentTypeId: 'SALES_SHIPMENT',
         keyword: params.queryString || '',
         orderBy: '-orderDate',
-        pageSize: import.meta.env.VITE_VIEW_SIZE,
+        pageSize: 200,
         pageIndex: params.viewIndex || 0
       } as any
 
-      if (!useProductStore().isProductStoreSettingEnabled('SHOW_SHIPPING_ORDERS')) {
-        queryParams.shipmentMethodTypeIds = 'STOREPICKUP'
+      if (params.shipmentMethodTypeIds) {
+        queryParams.shipmentMethodTypeIds = params.shipmentMethodTypeIds
       }
 
       try {
+        let total = 0;
+        do {
         resp = await api({
           url: `/poorti/shipments`,
           method: "GET",
@@ -516,7 +505,7 @@ export const useOrderStore = defineStore('order', {
 
           const pickers = await this.fetchPickersInformation({ shipmentIds, shipmentStatusId: 'SHIPMENT_PACKED' });
 
-          let total = resp.data.shipmentCount;
+          total = total || resp.data.shipmentCount;
           let orders = shipments.map((shipment: any) => {
             const validItems = shipment.items.filter((item: any) => item.orderItemStatusId !== 'ITEM_CANCELLED');
             if (validItems.length === 0) {
@@ -544,44 +533,40 @@ export const useOrderStore = defineStore('order', {
             currentOrders: orders
           });
 
-          orders = params.viewIndex && params.viewIndex > 0 ? this.packed.list.concat(packedOrders) : packedOrders;
+          orders = this.packed.list.concat(packedOrders);
           this.packed = { list: orders, total };
-
-          if (params.viewIndex === 0) emitter.emit("dismissLoader");
+          queryParams["pageIndex"]++;
         } else {
           this.packed = { list: [], total: 0 };
         }
 
-        emitter.emit("dismissLoader");
-        return resp;
+        } while(this.packed.list.length < total)
       } catch (err) {
         logger.error(err);
         commonUtil.showToast(translate("Something went wrong"));
-        emitter.emit("dismissLoader");
       }
     },
     async fetchCompletedOrders(params: any) {
-      if (params.viewIndex === 0) emitter.emit("presentLoader");
-
       const productStore = useProduct();
 
-      const userStore = useUserStore();
       const queryParams = {
         statusId: 'SHIPMENT_SHIPPED',
         originFacilityId: (useProductStore().getCurrentFacility?.facilityId || ""),
         shipmentTypeId: 'SALES_SHIPMENT',
         keyword: params.queryString || '',
         orderBy: '-orderDate',
-        pageSize: import.meta.env.VITE_VIEW_SIZE,
+        pageSize: 200,
         pageIndex: params.viewIndex || 0
       } as any
 
-      if (!useProductStore().isProductStoreSettingEnabled('SHOW_SHIPPING_ORDERS')) {
-        queryParams.shipmentMethodTypeIds = 'STOREPICKUP'
+      if (params.shipmentMethodTypeIds) {
+        queryParams.shipmentMethodTypeIds = params.shipmentMethodTypeIds
       }
 
       try {
-        const resp = await api({
+        let resp, total = 0;
+        do{
+        resp = await api({
           url: `/poorti/shipments`,
           method: "GET",
           params: queryParams
@@ -594,7 +579,7 @@ export const useOrderStore = defineStore('order', {
 
           const pickers = await this.fetchPickersInformation({ shipmentIds, shipmentStatusId: 'SHIPMENT_SHIPPED' });
 
-          let total = resp.data.shipmentCount;
+          total = resp.data.shipmentCount;
           let orders = shipments.map((shipment: any) => {
             const validItems = shipment.items.filter((item: any) => item.orderItemStatusId !== 'ITEM_CANCELLED');
             if (validItems.length === 0) {
@@ -622,19 +607,16 @@ export const useOrderStore = defineStore('order', {
             currentOrders: orders
           });
 
-          orders = params.viewIndex && params.viewIndex > 0 ? this.completed.list.concat(completedOrders) : completedOrders;
+          orders = this.completed.list.concat(completedOrders);
           this.completed = { list: orders, total };
-          if (params.viewIndex === 0) emitter.emit("dismissLoader");
+          queryParams["pageIndex"]++;
         } else {
           this.completed = { list: [], total: 0 };
         }
-
-        emitter.emit("dismissLoader");
-        return resp;
+        } while(this.completed.list.length < total)
       } catch (err) {
         logger.error(err);
         commonUtil.showToast(translate("Something went wrong"));
-        emitter.emit("dismissLoader");
       }
     },
     async getCommunicationEvents(params: any) {

--- a/src/store/order.ts
+++ b/src/store/order.ts
@@ -638,7 +638,7 @@ export const useOrderStore = defineStore('order', {
         commonUtil.showToast(translate("Something went wrong"));
       }
     },
-    async getCommunicationEvents(params: any) {
+    async fetchCommunicationEvents(params: any) {
       try {
         const completedOrdersList = params.orders.map((completedOrderData: any) => completedOrderData.orderId);
         const orderCommunicationEvents = this.communicationEvents;
@@ -660,8 +660,7 @@ export const useOrderStore = defineStore('order', {
         });
 
         if (!commonUtil.hasError(resp) && resp.data && resp.data.communicationEventList) {
-          const mergedOrdersList = [...orderCommunicationEvents, ...(resp.data.communicationEventList || [])];
-          this.communicationEvents = mergedOrdersList;
+          this.communicationEvents = [...orderCommunicationEvents, ...(resp.data.communicationEventList || [])];
           return resp.data.communicationEventList;
         } else {
           throw resp.data;

--- a/src/store/order.ts
+++ b/src/store/order.ts
@@ -38,6 +38,7 @@ export const useOrderStore = defineStore('order', {
         orderCount: 0
       }
     },
+    searchedQuery: "",
     orders: {} as any,
     communicationEvents: [] as any,
     rejectReasons: [] as any,
@@ -47,10 +48,28 @@ export const useOrderStore = defineStore('order', {
   }),
   getters: {
     getOrders: (state) => state.orders,
-    getOpenOrders: (state) => [...state.open.list].sort((a: any, b: any) => b.orderDate - a.orderDate),
+    getOpenOrders: (state) => {
+      let orders = [...state.open.list].sort((a: any, b: any) => b.orderDate - a.orderDate)
+      if(state.searchedQuery && orders.length) {
+        orders = orders.filter(order => order.orderId.toLowerCase().includes(state.searchedQuery.toLowerCase()) || order.orderName.toLowerCase().includes(state.searchedQuery.toLowerCase()))
+      }
+      return orders;
+    },
     getCurrent: (state) => JSON.parse(JSON.stringify(state.current)),
-    getPackedOrders: (state) => [...state.packed.list].sort((a: any, b: any) => b.orderDate - a.orderDate),
-    getCompletedOrders: (state) => [...state.completed.list].sort((a: any, b: any) => b.orderDate - a.orderDate),
+    getPackedOrders: (state) => {
+      let orders = [...state.packed.list].sort((a: any, b: any) => b.orderDate - a.orderDate)
+      if(state.searchedQuery && orders.length) {
+        orders = orders.filter(order => order.orderId.toLowerCase().includes(state.searchedQuery.toLowerCase()) || order.orderName.toLowerCase().includes(state.searchedQuery.toLowerCase()))
+      }
+      return orders;
+    },
+    getCompletedOrders: (state) => {
+      let orders = [...state.completed.list].sort((a: any, b: any) => b.orderDate - a.orderDate)
+      if(state.searchedQuery && orders.length) {
+        orders = orders.filter(order => order.orderId.toLowerCase().includes(state.searchedQuery.toLowerCase()) || order.orderName.toLowerCase().includes(state.searchedQuery.toLowerCase()))
+      }
+      return orders
+    },
     getShipToStoreIncomingOrders: (state) => state.shipToStore.incoming.list,
     isShipToStoreIncmngOrdrsScrlbl: (state) => state.shipToStore.incoming.orderCount > 0 && state.shipToStore.incoming.orderCount < state.shipToStore.incoming.total,
     getShipToStoreReadyForPickupOrders: (state) => state.shipToStore.readyForPickup.list,

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -194,7 +194,7 @@ onIonViewWillEnter(() => {
   queryString.value = '';
 
   segmentSelected.value = order.value?.orderType || "open"
-
+  searchOrders()
   if (segmentSelected.value === 'open') {
     getPickupOrders()
   } else if (segmentSelected.value === 'packed') {
@@ -287,7 +287,7 @@ async function getCompletedOrders(vSize?: any, vIndex?: any) {
   if(useProductStore().isProductStoreSettingEnabled('SHOW_SHIPPING_ORDERS')) {
     await useOrderStore().fetchCompletedOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (currentFacility.value as any)?.facilityId });
   }
-  if (useUserStore().hasPermission(Actions.APP_PROOF_OF_DELIVERY_PREF_UPDATE)) await useOrderStore().getCommunicationEvents({ orders: completedOrders.value });
+  // if (useUserStore().hasPermission(Actions.APP_PROOF_OF_DELIVERY_PREF_UPDATE)) await useOrderStore().getCommunicationEvents({ orders: completedOrders.value });
   emitter.emit("dismissLoader")
 }
 
@@ -334,6 +334,7 @@ async function deliverShipment(orderData: any) {
 function segmentChanged(e: CustomEvent) {
   queryString.value = ''
   segmentSelected.value = e.detail.value
+  searchOrders()
 
   if (segmentSelected.value === 'open') {
     getPickupOrders()

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -345,13 +345,7 @@ function segmentChanged(e: CustomEvent) {
 }
 
 async function searchOrders() {
-  if (segmentSelected.value === 'open') {
-    getPickupOrders()
-  } else if (segmentSelected.value === 'packed') {
-    getPackedOrders()
-  } else {
-    getCompletedOrders()
-  }
+  useOrderStore().searchedQuery = queryString.value.trim();
 }
 
 function selectSearchBarText(event: any) {

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -1,6 +1,6 @@
 <template>
   <ion-page>
-    <ion-header :translucent="true">
+    <ion-header>
       <ion-toolbar>
         <ion-title>{{ (currentFacility as any)?.facilityName ? (currentFacility as any)?.facilityName : (currentFacility as any)?.facilityId }}</ion-title>
         <ion-buttons slot="end">
@@ -28,7 +28,7 @@
         </ion-segment>
       </div>    
     </ion-header>
-    <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()">
+    <ion-content>
       <div data-testid="open-orders-container" v-if="segmentSelected === 'open' && orders.length">
 
         <div v-for="(order, index) in getOrdersByPart(orders)" :key="index" v-show="order.shipGroups.length > 0">
@@ -138,17 +138,12 @@
       <ion-refresher slot="fixed" @ionRefresh="refreshOrders($event)">
         <ion-refresher-content pullingIcon="crescent" refreshingSpinner="crescent" />
       </ion-refresher>
-      <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" 
-        v-show="(segmentSelected === 'open' ? isOpenOrdersScrollable : segmentSelected === 'packed' ? isPackedOrdersScrollable : isCompletedOrdersScrollable)"
-        ref="infiniteScrollRef">
-        <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')" />
-      </ion-infinite-scroll>
     </ion-content>
   </ion-page>
 </template>
 
 <script setup lang="ts">
-import { alertController, IonBadge, IonButton, IonButtons, IonCard, IonContent, IonHeader, IonIcon, IonInfiniteScroll, IonInfiniteScrollContent, IonItem, IonLabel, IonPage, IonRefresher, IonRefresherContent, IonSearchbar, IonSegment, IonSegmentButton, IonTitle, IonToolbar, modalController, onIonViewWillEnter } from "@ionic/vue";
+import { alertController, IonBadge, IonButton, IonButtons, IonCard, IonContent, IonHeader, IonIcon, IonItem, IonLabel, IonPage, IonRefresher, IonRefresherContent, IonSearchbar, IonSegment, IonSegmentButton, IonTitle, IonToolbar, modalController, onIonViewWillEnter } from "@ionic/vue";
 import { onMounted, onUnmounted, ref, computed } from "vue";
 import ProductListItem from '@/components/ProductListItem.vue'
 import { mailOutline, notificationsOutline, printOutline, trailSignOutline } from "ionicons/icons";
@@ -165,17 +160,11 @@ import { useProductStore } from "@/store/productStore"
 import Actions from "@/authorization/actions"
 
 const queryString = ref('');
-const isScrollingEnabled = ref(false);
 const segmentSelected = ref('open');
-const contentRef = ref(null as any);
-const infiniteScrollRef = ref(null as any);
 
 const orders = computed(() => useOrderStore().getOpenOrders);
 const packedOrders = computed(() => useOrderStore().getPackedOrders);
 const completedOrders = computed(() => useOrderStore().getCompletedOrders);
-const isPackedOrdersScrollable = computed(() => useOrderStore().isPackedOrdersScrollable);
-const isOpenOrdersScrollable = computed(() => useOrderStore().isOpenOrdersScrollable);
-const isCompletedOrdersScrollable = computed(() => useOrderStore().isCompletedOrdersScrollable);
 const notifications = computed(() => useNotificationStore().getNotifications);
 const unreadNotificationsStatus = computed(() => useNotificationStore().hasUnreadNotifications);
 const isHandoverProofEnabled = computed(() => useProductStore().isHandoverProofEnabled)
@@ -202,7 +191,6 @@ onUnmounted(() => {
 });
 
 onIonViewWillEnter(() => {
-  isScrollingEnabled.value = false;
   queryString.value = '';
 
   segmentSelected.value = order.value?.orderType || "open"
@@ -269,63 +257,38 @@ async function viewOrder(orderData: any, shipGroupSeqId: any, orderType: any) {
 async function getPickupOrders(vSize?: any, vIndex?: any) {
   const viewSize = vSize ? vSize : import.meta.env.VITE_VIEW_SIZE;
   const viewIndex = vIndex ? vIndex : 0;
+  emitter.emit("presentLoader")
+  useOrderStore().clearOrders();
   await useOrderStore().fetchOpenOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (currentFacility.value as any)?.facilityId });
+  if(useProductStore().isProductStoreSettingEnabled('SHOW_SHIPPING_ORDERS')) {
+    await useOrderStore().fetchOpenOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (currentFacility.value as any)?.facilityId, showShippingOrders: true });
+  }
+  emitter.emit("dismissLoader")
 }
 
 async function getPackedOrders(vSize?: any, vIndex?: any) {
   const viewSize = vSize ? vSize : import.meta.env.VITE_VIEW_SIZE;
   const viewIndex = vIndex ? vIndex : 0;
-  await useOrderStore().fetchPackedOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (currentFacility.value as any)?.facilityId });
+  emitter.emit("presentLoader")
+  useOrderStore().clearOrders();
+  await useOrderStore().fetchPackedOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (currentFacility.value as any)?.facilityId, shipmentMethodTypeIds: "STOREPICKUP" });
+  if(useProductStore().isProductStoreSettingEnabled('SHOW_SHIPPING_ORDERS')) {
+    await useOrderStore().fetchPackedOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (currentFacility.value as any)?.facilityId });
+  }
+  emitter.emit("dismissLoader")
 }
 
 async function getCompletedOrders(vSize?: any, vIndex?: any) {
   const viewSize = vSize ? vSize : import.meta.env.VITE_VIEW_SIZE;
   const viewIndex = vIndex ? vIndex : 0;
-  await useOrderStore().fetchCompletedOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (currentFacility.value as any)?.facilityId });
+  emitter.emit("presentLoader")
+  useOrderStore().clearOrders();
+  await useOrderStore().fetchCompletedOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (currentFacility.value as any)?.facilityId, shipmentMethodTypeIds: "STOREPICKUP" });
+  if(useProductStore().isProductStoreSettingEnabled('SHOW_SHIPPING_ORDERS')) {
+    await useOrderStore().fetchCompletedOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (currentFacility.value as any)?.facilityId });
+  }
   if (useUserStore().hasPermission(Actions.APP_PROOF_OF_DELIVERY_PREF_UPDATE)) await useOrderStore().getCommunicationEvents({ orders: completedOrders.value });
-}
-
-function enableScrolling() {
-  const parentElement = contentRef.value?.$el
-  if(!parentElement) return;
-  const scrollEl = parentElement.shadowRoot?.querySelector("div[part='scroll']")
-  if(!scrollEl) return;
-  
-  let scrollHeight = scrollEl.scrollHeight, infiniteHeight = infiniteScrollRef.value?.$el.offsetHeight, scrollTop = scrollEl.scrollTop, threshold = 100, height = scrollEl.offsetHeight
-  const distanceFromInfinite = scrollHeight - infiniteHeight - scrollTop - threshold - height
-  if (distanceFromInfinite < 0) {
-    isScrollingEnabled.value = false;
-  } else {
-    isScrollingEnabled.value = true;
-  }
-}
-
-async function loadMoreProducts(event: any) {
-  if (!(isScrollingEnabled.value && (segmentSelected.value === 'open' ? isOpenOrdersScrollable.value : segmentSelected.value === 'packed' ? isPackedOrdersScrollable.value : isCompletedOrdersScrollable.value))) {
-    await event.target.complete();
-  }
-  if (segmentSelected.value === 'open') {
-    getPickupOrders(
-      undefined,
-      Math.ceil(orders.value.length / (import.meta.env.VITE_VIEW_SIZE as any)).toString()
-    ).then(async () => {
-      await event.target.complete();
-    });
-  } else if (segmentSelected.value === 'packed') {
-    getPackedOrders(
-      undefined,
-      Math.ceil(packedOrders.value.length / (import.meta.env.VITE_VIEW_SIZE as any)).toString()
-    ).then(async () => {
-      await event.target.complete();
-    });
-  } else {
-    getCompletedOrders(
-      undefined,
-      Math.ceil(completedOrders.value.length / (import.meta.env.VITE_VIEW_SIZE as any)).toString()
-    ).then(async () => {
-      await event.target.complete();
-    });
-  }
+  emitter.emit("dismissLoader")
 }
 
 async function readyForPickup(orderData: any, shipGroup: any) {

--- a/src/views/Orders.vue
+++ b/src/views/Orders.vue
@@ -287,7 +287,7 @@ async function getCompletedOrders(vSize?: any, vIndex?: any) {
   if(useProductStore().isProductStoreSettingEnabled('SHOW_SHIPPING_ORDERS')) {
     await useOrderStore().fetchCompletedOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (currentFacility.value as any)?.facilityId });
   }
-  // if (useUserStore().hasPermission(Actions.APP_PROOF_OF_DELIVERY_PREF_UPDATE)) await useOrderStore().getCommunicationEvents({ orders: completedOrders.value });
+  if (useUserStore().hasPermission(Actions.APP_PROOF_OF_DELIVERY_PREF_UPDATE)) await useOrderStore().fetchCommunicationEvents({ orders: completedOrders.value });
   emitter.emit("dismissLoader")
 }
 
@@ -567,7 +567,7 @@ async function openProofOfDeliveryModal(orderData: any, isViewModeOnly: any) {
         logger.error("Pickup notification failed:", resp);
         commonUtil.showToast(translate("Unable to save the details. Please try again."));
       } else {
-        await useOrderStore().getCommunicationEvents({ orders: [order.value] });
+        await useOrderStore().fetchCommunicationEvents({ orders: [order.value] });
         commonUtil.showToast(translate("Details have been successfully saved, and an email has been sent to the customer."));
       }
     } catch (err) {

--- a/src/views/ShipToStoreOrders.vue
+++ b/src/views/ShipToStoreOrders.vue
@@ -163,7 +163,7 @@ const getCompletedOrders = async (vSize?: any, vIndex?: any) => {
   const viewSize = vSize ? vSize : (import.meta.env.VITE_VIEW_SIZE as any);
   const viewIndex = vIndex ? vIndex : 0;
   await (useOrderStore() as any).getShipToStoreCompletedOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (useProductStore().getCurrentFacility as any)?.facilityId });
-  await (useOrderStore() as any).getCommunicationEvents({ orders: completedOrders.value });
+  await (useOrderStore() as any).fetchCommunicationEvents({ orders: completedOrders.value });
 };
 
 const refreshOrders = async (event: any) => {
@@ -406,7 +406,7 @@ const openProofOfDeliveryModal = async (order: any, isViewModeOnly: any) => {
         logger.error("Pickup notification failed:", resp);
         commonUtil.showToast(translate("Unable to save the details. Please try again."));
       } else {
-        await (useOrderStore() as any).getCommunicationEvents({ orders: [order] });
+        await (useOrderStore() as any).fetchCommunicationEvents({ orders: [order] });
         commonUtil.showToast(translate("Details have been successfully saved, and an email has been sent to the customer."));
       }
     } catch (err) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#820 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added support to show shipping orders and pickup orders together when SHOW_SHIPPING_ORDERS setting is enabled
- Fetch all orders at once and removed infinite scroll
- Implemented searching logic in app instead of making api calls, as we have all orders in app

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
