### PR TITLE
Fixed: request runTime instead of non-existent nextExecutionDateTime in fetchJobs

### DIFF
--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -446,7 +446,7 @@ async function fetchJobs() {
       "systemJobEnumId": "JOB_UL_CNCLD_ORD",
       "systemJobEnumId_op": "equals"
     },
-    "fieldList": ["systemJobEnumId", "statusId", "tempExprId", "nextExecutionDateTime"],
+    "fieldList": ["systemJobEnumId", "statusId", "tempExprId", "runTime"],
     "noConditionFind": "Y",
     "viewSize": 1
   }
@@ -455,7 +455,7 @@ async function fetchJobs() {
     const resp = await useOrderStore().fetchJobInformation(params)
     if(!commonUtil.hasError(resp) && resp.data.count > 0) {
       isCancelationSyncJobEnabled.value = true;
-      cancelJobNextRunTime.value = resp.data.docs[0].nextExecutionDateTime;
+      cancelJobNextRunTime.value = resp.data.docs[0].runTime;
     }
 
     const refundStatusResp = await useOrderStore().getProcessRefundStatus(useProductStore().getCurrentProductStore.productStoreId)


### PR DESCRIPTION
Fixes #845.

`fetchJobs()` on OrderDetail asked `/findJobs` for `nextExecutionDateTime`, which does not exist on the `SystemJobAndProduct` view. The find failed every time with `invalid field names specified: [nextExecutionDateTime]` in OMS logs, the app swallowed the error, and the canceled-order-sync info (`JOB_UL_CNCLD_ORD` next run) never rendered.

The job's next run time on JobSandbox is `runTime`. This PR requests `runTime` in the fieldList and reads `docs[0].runTime`.

Verified against Gorjana production logs; the invalid-field error stops once deployed.