### PR TITLE
Fixed: notifications issue as the token registration is gated in preferences condition causing the device to not getting registered and subscription fails

### DIFF
--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -242,7 +242,10 @@ export const useUserStore = defineStore("user", {
 
         const notificationStore = useNotificationStore();
         await notificationStore.fetchAllNotificationPrefs(import.meta.env.VITE_NOTIF_APP_ID as any, this.current.userId)
-        await firebaseUtil.initialiseFirebaseMessaging();
+        // Register the device token only when we have some notification preferences already set
+        if(notificationStore.getAllNotificationPrefs?.length) {
+          await firebaseUtil.initialiseFirebaseMessaging();
+        }
 
         const facilityId = router.currentRoute.value.query.facilityId
         if (facilityId) {

--- a/src/utils/firebaseUtil.ts
+++ b/src/utils/firebaseUtil.ts
@@ -8,7 +8,7 @@ const initialiseFirebaseMessaging = async () => {
   const appFirebaseConfig = JSON.parse(import.meta.env.VITE_FIREBASE_CONFIG as any);
   const appFirebaseVapidKey = import.meta.env.VITE_FIREBASE_VAPID_KEY;
 
-  if (appFirebaseConfig && appFirebaseConfig.apiKey && notificationStore.getAllNotificationPrefs?.length) {
+  if (appFirebaseConfig && appFirebaseConfig.apiKey) {
     await firebaseMessaging.initialiseFirebaseApp(
       appFirebaseConfig,
       appFirebaseVapidKey,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Removed the preferences check from the notification util and moved it to the login flow, so that if notifications preferences are not found on login do not register the device, but if someone is subscribing from the settings page, the device registration should be done.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)
