### PR TITLE
Fixed: Action name collision breaking Ship to Store order fetching

### DIFF
--- a/src/store/order.ts
+++ b/src/store/order.ts
@@ -829,7 +829,7 @@ export const useOrderStore = defineStore('order', {
         return err as any
       }
     },
-    async getShipToStoreIncomingOrders(payload: any) {
+    async fetchShipToStoreIncomingOrders(payload: any) {
       if (payload.viewIndex === 0) emitter.emit("presentLoader")
       let resp: any
       const params = {
@@ -891,7 +891,7 @@ export const useOrderStore = defineStore('order', {
       }
       return resp;
     },
-    async getShipToStoreReadyForPickupOrders(payload: any) {
+    async fetchShipToStoreReadyForPickupOrders(payload: any) {
       if (payload.viewIndex === 0) emitter.emit("presentLoader")
       let resp: any
       const params = {
@@ -953,7 +953,7 @@ export const useOrderStore = defineStore('order', {
       }
       return resp;
     },
-    async getShipToStoreCompletedOrders(payload: any) {
+    async fetchShipToStoreCompletedOrders(payload: any) {
       if (payload.viewIndex === 0) emitter.emit("presentLoader")
       let resp: any
       const params = {

--- a/src/views/ShipToStoreOrders.vue
+++ b/src/views/ShipToStoreOrders.vue
@@ -150,19 +150,19 @@ const getDateTime = (time: any) => {
 const getIncomingOrders = async (vSize?: any, vIndex?: any) => {
   const viewSize = vSize ? vSize : (import.meta.env.VITE_VIEW_SIZE as any);
   const viewIndex = vIndex ? vIndex : 0;
-  await (useOrderStore() as any).getShipToStoreIncomingOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (useProductStore().getCurrentFacility as any)?.facilityId });
+  await (useOrderStore() as any).fetchShipToStoreIncomingOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (useProductStore().getCurrentFacility as any)?.facilityId });
 };
 
 const getReadyForPickupOrders = async (vSize?: any, vIndex?: any) => {
   const viewSize = vSize ? vSize : (import.meta.env.VITE_VIEW_SIZE as any);
   const viewIndex = vIndex ? vIndex : 0;
-  await (useOrderStore() as any).getReadyForPickupOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (useProductStore().getCurrentFacility as any)?.facilityId });
+  await (useOrderStore() as any).fetchShipToStoreReadyForPickupOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (useProductStore().getCurrentFacility as any)?.facilityId });
 };
 
 const getCompletedOrders = async (vSize?: any, vIndex?: any) => {
   const viewSize = vSize ? vSize : (import.meta.env.VITE_VIEW_SIZE as any);
   const viewIndex = vIndex ? vIndex : 0;
-  await (useOrderStore() as any).getShipToStoreCompletedOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (useProductStore().getCurrentFacility as any)?.facilityId });
+  await (useOrderStore() as any).fetchShipToStoreCompletedOrders({ viewSize, viewIndex, queryString: queryString.value, facilityId: (useProductStore().getCurrentFacility as any)?.facilityId });
   await (useOrderStore() as any).fetchCommunicationEvents({ orders: completedOrders.value });
 };
 


### PR DESCRIPTION
## Summary

The Ship to Store Orders page (src/views/ShipToStoreOrders.vue) threw console errors like:
TypeError: useOrderStore().getReadyForPickupOrders is not a function
TypeError: (intermediate value)().getShipToStoreCompletedOrders is not a function
whenever user switched between the Incoming / Ready for Pickup / Completed tabs.

### Fix
Renamed the three actions (not the getters — those are still used by computed() refs in the view) to match this store's existing fetch* naming convention:

- getShipToStoreIncomingOrders → fetchShipToStoreIncomingOrders
- getShipToStoreReadyForPickupOrders → fetchShipToStoreReadyForPickupOrders
- getShipToStoreCompletedOrders → fetchShipToStoreCompletedOrders

Updated the three matching call sites in ShipToStoreOrders.vue (getIncomingOrders, getReadyForPickupOrders, getCompletedOrders). 


Net code changes: only src/store/order.ts (3 action renames) and src/views/ShipToStoreOrders.vue (3 call-site updates). All three tabs (Incoming, Ready for Pickup, Completed) should now correctly call their fetch actions.

### Closes: https://github.com/hotwax/bopis/issues/865